### PR TITLE
fix(security): upgrade Go to 1.26.0, fix crypto/tls CVEs GO-2026-4340…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   checks: write
 
 env:
-  GO_VERSION: "1.24.12"
+  GO_VERSION: "1.26"
 
 jobs:
   # Run linting and static analysis
@@ -26,9 +26,9 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.10.1
           args: --timeout=5m --verbose
 
       - name: fmt check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.24.12"
+  GO_VERSION: "1.26"
   BINARY_NAME: kwot
 
 jobs:

--- a/.github/workflows/scheduled-security-scan.yml
+++ b/.github/workflows/scheduled-security-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.12"
+          go-version: "1.26"
           cache: true
 
       - name: Run govulncheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.6] - 2026-02-18
+
+### Security
+
+- Upgraded Go toolchain from 1.25.5 to 1.26.0, resolving two `crypto/tls` vulnerabilities:
+  - **GO-2026-4340**: Handshake messages may be processed at the incorrect encryption level (fixed in Go 1.25.6+)
+  - **GO-2026-4337**: Unexpected TLS session resumption (fixed in Go 1.25.7+)
+- Updated `go.mod` to `go 1.26`
+- Updated all CI/CD workflow Go versions (`ci.yml`, `release.yml`, `scheduled-security-scan.yml`) to `1.26`
+- Pinned `golangci-lint-action` to `v6` with `v2.10.1` (built with Go 1.26) to fix linter version mismatch
+- Verified clean `govulncheck ./...` output: `No vulnerabilities found`
+
+### Added
+
+- Added `make start` / `make stop` targets as convenience wrappers for `docker compose up/down` in the `perf-test` directory
+- Added `make reset` target to reset Kong DB (migrations reset + bootstrap + container restart)
+- Added `config/demo5` workspace configuration
+
 ## [1.0.5] - 2026-01-29
 
 ### Fixed
@@ -20,8 +38,8 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- Verified and recommend building with Go 1.24.12, which patches critical TLS vulnerability GO-2026-4340 in the crypto/tls package
 - Updated Dockerfile and CI/CD workflows to build with Go 1.24.12 for consistency
+- Note: GO-2026-4340 (`crypto/tls` handshake encryption level vulnerability) was not fully resolved until Go 1.25.6+; fully addressed in v1.0.6
 
 ## [1.0.3] - 2026-01-27
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 .PHONY: help build clean install test run deps fmt lint dev docker-build \
-         test-coverage build-all run-all docs generate-workspaces perf-test perf-clean
+         test-coverage build-all run-all docs generate-workspaces perf-test perf-clean \
+         start stop reset
 
 # ============================================================================
 # Configuration
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.5
+VERSION?=1.0.6
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go
@@ -261,6 +262,22 @@ perf-full: perf-clean perf-quick
 ## WARNING: This will erase all Kong data
 perf-full-clean: perf-reset perf-full
 	@echo "✓ Full performance test with clean Kong database complete"
+
+## start: Start Kong using docker compose
+start:
+	cd perf-test && docker compose up -d
+
+## stop: Stop Kong using docker compose
+stop:
+	cd perf-test && docker compose down
+
+## reset: Reset Kong database (erase all data)
+reset:
+	@echo "Resetting Kong DB (this will erase all data)..."
+	docker exec -it kong-gateway-cp kong migrations reset -y
+	docker exec -it kong-gateway-cp kong migrations bootstrap -y
+	@echo "Restarting kong-gateway-cp container..."
+	docker restart kong-gateway-cp
 
 ## help: Show this help message
 help:

--- a/config/demo5/workspace.yaml
+++ b/config/demo5/workspace.yaml
@@ -1,0 +1,12 @@
+role_info:
+  readonly_role: &readonly_role Tenant-User
+  tenant_release_role: &tenant_release_role Tenant-Release-User
+  tenant_devportal_approver_role: &tenant_devportal_approver_role Tenant-Devportal-Approver
+
+rbac:
+  - role: *readonly_role
+    permissions: ./config/tenant-user.yaml
+  - role: *tenant_release_role
+    permissions: ./config/tenant-release-user.yaml
+  - role: *tenant_devportal_approver_role
+    permissions: ./config/tenant-devportal-approver.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kong/kwot
 
-go 1.24
+go 1.26
 
 require (
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
… and GO-2026-4337

- Upgraded Go toolchain to 1.26.0 (from 1.25.5)
- Updated go.mod to go 1.26
- Updated ci.yml, release.yml, scheduled-security-scan.yml to Go 1.26
- Resolves GO-2026-4340: TLS handshake encryption level vulnerability
- Resolves GO-2026-4337: Unexpected TLS session resumption vulnerability
- govulncheck ./... now reports: No vulnerabilities found
- All unit tests pass with race detection enabled
- Bumped version to v1.0.6