### PR TITLE
feat: per-workspace groups config, workspace deletion cleanup, and group auto-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 - Per-workspace `groups-and-roles.yaml` support — place a `groups-and-roles.yaml` inside a workspace directory and it takes priority over the global file
 - Configuration File Reference section in README documenting all YAML schemas (`workspace.yaml`, `workspace-rbac-user.yaml`, `groups-and-roles.yaml`)
 - `IsDebugEnabled()` helper in logger to gate expensive debug-only API calls
+- Workspace deletion now cleans up additional Kong Enterprise entity types:
+  - Custom plugin schemas (`/custom-plugins`)
+  - Standalone DeGraphQL routes (`/degraphql_routes`)
+  - OIDC JWK sets (`/oic_jwks`)
+  - Dev Portal partials (`/partials`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.7] - 2026-03-27
+
+### Added
+
+- Auto-cleanup of group-role assignments and empty groups during workspace deletion
+  - When deleting a workspace, kwot now removes all group-role mappings for that workspace (Step 0)
+  - Groups that become fully empty after removal are automatically deleted
+  - Multi-workspace groups retain their role mappings for other workspaces
+- Per-workspace `groups-and-roles.yaml` support — place a `groups-and-roles.yaml` inside a workspace directory and it takes priority over the global file
+- Configuration File Reference section in README documenting all YAML schemas (`workspace.yaml`, `workspace-rbac-user.yaml`, `groups-and-roles.yaml`)
+- `IsDebugEnabled()` helper in logger to gate expensive debug-only API calls
+
+### Fixed
+
+- `ProcessRoles` now validates that the workspace exists before proceeding, preventing silent success for nonexistent workspaces
+- `errors.Is(err, os.ErrNotExist)` used throughout group config loading to correctly unwrap wrapped errors from `fmt.Errorf("%w", ...)`
+- `countWorkspaceEntities` returns -1 on any pagination error to prevent acting on partial/unreliable counts
+- `debugLogRemainingEntities` gated behind `IsDebugEnabled()` to avoid unnecessary Kong API calls on non-verbose runs
+- Global `groups-and-roles.yaml` in all-mode now filters roles per workspace rather than skipping entire groups
+
 ## [1.0.6] - 2026-02-18
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,229 @@
+# CLAUDE.md
+
+This file gives LLM agents a practical working guide for the `kwot` repository.
+
+## Project Identity
+
+- Name: `kwot` (Kong Workspace Onboarding Tool)
+- Language: Go
+- Type: single-binary CLI (Cobra-based)
+- Purpose: manage Kong Enterprise workspace onboarding via YAML-driven Infrastructure as Code
+- Scope: workspaces, RBAC roles, RBAC users, groups, workspace-level plugins, drift detection, deletion
+- Repo: https://github.com/Kong/kwot
+
+## What This Tool Solves
+
+`kwot` removes manual Kong Manager setup for platform teams.
+
+It automates:
+- Workspace creation and updates
+- Role creation and permission assignment
+- RBAC user creation
+- Group creation and role mapping per workspace
+- Drift detection (`kwot diff`)
+- Safe teardown (`kwot delete ... --force` with feature flags)
+
+It is intentionally focused on workspace/admin onboarding and RBAC. For API-layer entities (services/routes/plugins at scale), use decK.
+
+## High-Level Flow
+
+Entry point:
+- `main.go` sets build-time `Version` and calls `cmd.Execute()`.
+
+Main command pipeline:
+1. `kwot apply` (default applies all)
+2. Workspaces processed first
+3. Roles processed second
+4. RBAC users applied after roles
+5. Groups processed last
+
+Why this order matters:
+- Groups need roles and workspaces to already exist
+- RBAC users depend on roles existing
+
+## Command Surface
+
+Defined in `cmd/`:
+- `root.go`: global flags, config init, logging mode, version/banner
+- `all.go`: `apply` command family
+- `diff.go`: drift detection (`all|workspaces|roles|groups`)
+- `delete.go`: destructive flows with safety checks and required `--force`
+
+Global flags:
+- `--workspace, -w` (default `all`)
+- `--dry-run`
+- `--verbose`
+- `--quiet`
+- `--config` for env file path
+
+## Configuration Model
+
+Loaded from env/.env in `internal/config/config.go`.
+
+Important env vars:
+- `KONG_ADDR` (default `http://localhost:8001`)
+- `AUTH_METHOD` (`RBAC` or `PASSWORD`)
+- `ADMIN_TOKEN` (required for RBAC)
+- `ADMIN_USER` + `BASE64_UID_PWD` (required for PASSWORD)
+- `CONFIG_DIR` (default `./config/`)
+- `MAX_CONCURRENT_WORKSPACES` (default `5`)
+- `MAX_RETRY_ATTEMPTS` (default `5`)
+
+Feature flags:
+- `FEATURE_DELETE_EXISTING_USERS`
+- `FEATURE_DELETE_EXISTING_ROLES`
+- `FEATURE_CREATE_RBAC_USERS`
+- `FEATURE_DELETE_EXISTING_RBAC_USERS`
+- `FEATURE_FORCE_WIPE_WORKSPACE`
+- `FEATURE_DELETE_ALL_ENABLED`
+
+## Files and Data Layout
+
+Expected config structure under `CONFIG_DIR`:
+- `groups-and-roles.yaml` — **optional** global group definitions and role mappings (fallback)
+- `<workspace>/groups-and-roles.yaml` — **optional** per-workspace group definitions (takes priority over global)
+- `<workspace>/workspace.yaml` for workspace/rbac/plugin definitions
+- `<workspace>/workspace-rbac-user.yaml` for workspace RBAC users
+- shared permission files like `tenant-user.yaml`, `tenant-release-user.yaml`
+
+`groups-and-roles.yaml` lookup precedence (workspace-local wins):
+- For `-w <workspace>`: checks `<CONFIG_DIR>/<workspace>/groups-and-roles.yaml` first, then `<CONFIG_DIR>/groups-and-roles.yaml`
+- For `all`: each workspace dir is scanned — per-workspace file is used if present; the global file fills in any workspaces that lack a local file
+- Both formats are supported in either location: direct array or `role_info`+`config` structured format
+
+Processor ownership:
+- `internal/workspace/processor.go`
+- `internal/roles/processor.go`
+- `internal/groups/processor.go`
+
+Model types:
+- `internal/models/`
+
+Validation:
+- `internal/validation/validator.go`
+
+## Kong Client Behavior
+
+`internal/kong/client.go`:
+- wraps HTTP methods (`GET`, `POST`, `PATCH`, `DELETE`)
+- supports RBAC token and PASSWORD auth
+- for PASSWORD auth, acquires cookies via `/auth`
+- supports custom CA bundle, TLS verify toggle, and proxy
+- normalizes Kong API errors into clearer messages
+
+## Concurrency and Pagination
+
+Concurrency:
+- workspace and role processing use bounded worker patterns
+- concurrency controlled by `MAX_CONCURRENT_WORKSPACES`
+- some per-role/per-group operations use additional semaphores
+
+Pagination:
+- list operations are paginated (`size=1000`, `offset` loop)
+- used for workspaces, groups, and roles where applicable
+
+## Safety Model
+
+Destructive commands require `--force`.
+Additional delete capabilities require feature flags.
+
+Examples:
+- workspace delete requires `FEATURE_FORCE_WIPE_WORKSPACE=true`
+- `delete all` requires `FEATURE_DELETE_ALL_ENABLED=true`
+
+`default` workspace is protected from deletion.
+
+## Development Commands
+
+Common Make targets:
+- `make deps`       download/tidy modules
+- `make fmt`        format Go code
+- `make lint`       run golangci-lint
+- `make test`       run unit tests
+- `make test-coverage`
+- `make build`      build `bin/kwot`
+- `make build-all`  cross-platform builds
+
+Recommended local validation sequence before merging:
+1. `make fmt`
+2. `make lint`
+3. `make test`
+4. `make build`
+
+## Testing and QA Notes
+
+Test files exist in:
+- `cmd/*_test.go`
+- `internal/**/_test.go`
+- shell-level tests in `tests/`
+
+When changing processors or CLI flow, prioritize:
+- dry-run behavior
+- workspace-scoped filtering (`-w`)
+- error clarity (especially role/group assignment failures)
+- backward compatibility of YAML formats
+
+## Editing Guidance for LLM Agents
+
+When making changes:
+- Preserve command behavior and apply order unless explicitly requested
+- Keep safety checks intact for delete paths
+- Maintain dry-run semantics (no live mutation in dry-run)
+- Avoid introducing breaking schema changes in YAML unless required
+- Prefer minimal targeted patches over broad refactors
+
+If touching group-role mapping logic, verify:
+- role names referenced in `groups-and-roles.yaml` actually exist in target workspace RBAC
+- group names can be arbitrary, but assigned role must exist in workspace context
+- `loadGroupConfig` resolves per-workspace file first, global fallback second — do not break this precedence
+- `parseGroupConfigFile` handles both YAML formats; keep it as the single parsing entry point
+
+## Common Pitfalls
+
+- Using built-in role names (`admin`, `readonlyrole`) in a workspace that defines only tenant roles (`Tenant-User`, etc.)
+- Forgetting required auth env vars for chosen auth mode
+- Expecting group deletion to be workspace-scoped (groups are global in Kong)
+- Running destructive commands without enabling required feature flags
+
+## Quick Operator Examples
+
+Preview changes:
+
+```bash
+kwot apply --dry-run
+```
+
+Apply all:
+
+```bash
+kwot apply
+```
+
+Apply only roles for one workspace:
+
+```bash
+kwot apply roles -w demo1
+```
+
+Diff everything:
+
+```bash
+kwot diff
+```
+
+Delete one workspace (if feature enabled):
+
+```bash
+kwot delete workspaces -n demo1 --force
+```
+
+---
+
+If you are an LLM agent, start by reading:
+1. `README.md`
+2. `cmd/root.go`
+3. `cmd/all.go`
+4. `internal/config/config.go`
+5. relevant processor in `internal/workspace`, `internal/roles`, or `internal/groups`
+
+Then make the smallest change that satisfies the user request.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.6
+VERSION?=1.0.7
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go

--- a/README.md
+++ b/README.md
@@ -144,6 +144,43 @@ CONFIG_DIR=./config/
 
 See [CHEATSHEET.md](CHEATSHEET.md#environment-configuration) for all environment variables.
 
+## Group Configuration Layout
+
+`groups-and-roles.yaml` can live either at the config root (global) or inside a workspace subdirectory (per-workspace). Per-workspace takes priority.
+
+**Option A — Global file (single file for all workspaces):**
+```
+config/
+  groups-and-roles.yaml   # all workspaces' groups defined here
+  teamA/
+  teamB/
+```
+
+**Option B — Per-workspace files (one file per workspace, no global):**
+```
+config/
+  teamA/
+    groups-and-roles.yaml   # teamA groups only
+    workspace.yaml
+  teamB/
+    groups-and-roles.yaml   # teamB groups only
+    workspace.yaml
+```
+
+**Option C — Mixed (per-workspace overrides, global as fallback):**
+```
+config/
+  groups-and-roles.yaml     # fallback for workspaces without a local file
+  teamA/
+    groups-and-roles.yaml   # teamA uses this, global is ignored for teamA
+  teamB/                    # teamB falls back to global
+    workspace.yaml
+```
+
+Both YAML formats are supported in any location:
+- **Direct array:** `- group_name: ...`
+- **Structured (with `role_info` anchors):** `role_info: {...}` + `config: [...]`
+
 ## Performance Tuning: Concurrency
 
 kwot processes workspaces concurrently for faster execution. Control parallelism with `MAX_CONCURRENT_WORKSPACES`:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See [CHEATSHEET.md](CHEATSHEET.md#environment-configuration) for all environment
 
 ## Configuration File Reference
 
-kwot reads three types of YAML files from your `CONFIG_DIR`. This section documents every field so you know exactly what to write.
+kwot primarily works with three core types of YAML files in your `CONFIG_DIR`, plus additional supporting YAML files (for example, a `root-workspace.yaml` and any external permission-set YAML files referenced from `workspace.yaml`). This section documents every field of these core config files so you know exactly what to write.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,157 @@ CONFIG_DIR=./config/
 
 See [CHEATSHEET.md](CHEATSHEET.md#environment-configuration) for all environment variables.
 
+## Configuration File Reference
+
+kwot reads three types of YAML files from your `CONFIG_DIR`. This section documents every field so you know exactly what to write.
+
+---
+
+### `workspace.yaml` — Workspace, Roles, and Plugins
+
+One file per workspace directory. Defines the workspace settings, the RBAC roles that exist inside it, and any workspace-level plugins to apply.
+
+```yaml
+# workspace config settings
+config:
+  portal: false           # true | false — enable Dev Portal for this workspace
+
+# RBAC roles to create inside this workspace
+rbac:
+  - role: readonlyrole    # role name (string, must be unique within the workspace)
+    permissions:
+      - endpoint: "*"     # Kong endpoint pattern — "*" means all endpoints
+        negative: false   # false = ALLOW, true = DENY
+        actions: "read"   # comma-separated: read, create, update, delete
+
+  - role: admin
+    permissions:
+      - endpoint: "*"
+        negative: false
+        actions: "create,update,read,delete"
+      - endpoint: "/rbac/*"   # deny RBAC management to prevent privilege escalation
+        negative: true
+        actions: "create,update,read,delete"
+
+# Workspace-level plugins (optional)
+plugins:
+  - name: "file-log"          # Kong plugin name
+    config:
+      path: /dev/stdout       # plugin-specific config keys
+      reopen: false
+
+  - name: "rate-limiting-advanced"
+    config:
+      limit: [10, 20]
+      window_size: [60, 120]
+      strategy: redis
+      redis:
+        host: redis.svc.cluster.local
+        port: 6379
+      sync_rate: 1
+```
+
+**Notes:**
+- `permissions` can reference a file path instead of an inline array (for shared permission sets).
+- `plugins` is optional — omit the key entirely if no plugins are needed.
+- Roles defined here are what you reference in `groups-and-roles.yaml`.
+
+---
+
+### `workspace-rbac-user.yaml` — Workspace RBAC Users
+
+One file per workspace directory. Defines workspace-scoped RBAC users and the roles they are assigned.
+
+```yaml
+- name: workspace-admin-user   # RBAC username (string)
+  roles:
+    - admin                    # role name — must exist in this workspace's rbac: block
+
+- name: readonly-svc-account
+  roles:
+    - readonlyrole
+```
+
+**Notes:**
+- Each entry creates one RBAC user and assigns it the listed roles within the workspace.
+- Roles must already exist (kwot applies roles before users).
+- This file is **optional** — omit it if you don't need workspace-scoped RBAC users.
+- Feature-flagged: requires `FEATURE_CREATE_RBAC_USERS=true` to take effect.
+
+---
+
+### `groups-and-roles.yaml` — Group-to-Role Mappings
+
+Maps IdP groups (LDAP/OIDC) to Kong RBAC roles across workspaces. Supports two formats.
+
+**Format 1 — Direct array (recommended for simple setups):**
+
+```yaml
+- group_name: platform-admins        # IdP group name (string)
+  group_comment: "Platform admin team"  # optional description
+  roles:
+    - workspace: demo1               # workspace name
+      role: admin                    # role name — must exist in that workspace
+    - workspace: demo2
+      role: admin
+
+- group_name: platform-readonly
+  group_comment: "Read-only access across all workspaces"
+  roles:
+    - workspace: demo1
+      role: readonlyrole
+    - workspace: demo2
+      role: readonlyrole
+```
+
+**Format 2 — Structured with YAML anchors (for DRY role name reuse):**
+
+```yaml
+# Define role name aliases once, reuse with YAML anchors
+role_info:
+  wk_admin: &wk_admin admin
+  readonly:  &readonly readonlyrole
+
+# The actual group definitions — same schema as Format 1
+config:
+  - group_name: platform-admins
+    group_comment: "Platform admin team"
+    roles:
+      - workspace: demo1
+        role: *wk_admin          # expands to "admin"
+      - workspace: demo2
+        role: *wk_admin
+
+  - group_name: platform-readonly
+    roles:
+      - workspace: demo1
+        role: *readonly          # expands to "readonlyrole"
+```
+
+**Notes:**
+- Both formats produce identical results — choose whichever suits your team.
+- Different workspace files can use different formats; they don't need to match.
+- `group_name` must match the exact IdP group name configured in Kong.
+- `group_comment` is optional.
+- A single group can map to roles in multiple workspaces (multiple entries under `roles:`).
+
+---
+
+### File Layout Summary
+
+```
+CONFIG_DIR/
+  groups-and-roles.yaml          # optional — global fallback for all workspaces
+  <workspace>/
+    workspace.yaml               # required — workspace config, roles, plugins
+    workspace-rbac-user.yaml     # optional — workspace RBAC users
+    groups-and-roles.yaml        # optional — per-workspace groups (overrides global)
+```
+
+Apply order: **workspaces → roles → RBAC users → groups**. Each step depends on the previous one existing in Kong.
+
+---
+
 ## Group Configuration Layout
 
 `groups-and-roles.yaml` can live either at the config root (global) or inside a workspace subdirectory (per-workspace). Per-workspace takes priority.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ When deleting workspaces, kwot automatically cleans up all workspace-scoped chil
 | **Certificates, SNIs, Upstreams** | ✅ Auto-deleted with workspace |
 | **Credentials & Vaults** (basic-auth, key-auth, hmac-auth, jwt, oauth2, mtls-auth) | ✅ Auto-deleted with workspace |
 | **Keys & Key Sets** (Kong Enterprise 3.1+) | ✅ Auto-deleted with workspace |
+| **Custom Plugin schemas** | ✅ Auto-deleted with workspace |
+| **DeGraphQL routes** (standalone + service-scoped) | ✅ Auto-deleted with workspace |
+| **OIDC JWK Sets** (`oic_jwks`) | ✅ Auto-deleted with workspace |
+| **Dev Portal Partials** | ✅ Auto-deleted with workspace |
 | **Group-role mappings & empty groups** | ✅ Auto-cleaned with workspace (see below) |
 
 #### Group cleanup during workspace deletion

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ When deleting workspaces, kwot automatically cleans up all workspace-scoped chil
 | **Plugins, Consumer Groups, ACLs** | ✅ Auto-deleted with workspace |
 | **Certificates, SNIs, Upstreams** | ✅ Auto-deleted with workspace |
 | **Credentials & Vaults** (basic-auth, key-auth, hmac-auth, jwt, oauth2, mtls-auth) | ✅ Auto-deleted with workspace |
+| **Keys & Key Sets** (Kong Enterprise 3.1+) | ✅ Auto-deleted with workspace |
+| **Group-role mappings & empty groups** | ✅ Auto-cleaned with workspace (see below) |
+
+#### Group cleanup during workspace deletion
+
+Kong groups are **global** — a single group can hold role mappings across multiple workspaces. When you delete a workspace, kwot handles group cleanup automatically as Step 0 of the deletion sequence:
+
+1. **Role mappings for this workspace are removed** from every group that references it.
+2. **Groups that become empty** (all their role mappings belonged to this workspace) are **deleted automatically**.
+3. **Multi-workspace groups** that still have role mappings in other workspaces are **left untouched** — only the mappings for the deleted workspace are removed.
+
+Example log output during `delete workspaces -n teamA --force`:
+```
+Step 0: Removing group-role assignments for workspace teamA
+Removed role assignment from group 'teamA-admin-group' (workspace: teamA)
+Group 'teamA-admin-group' has no remaining role assignments after workspace teamA removal — deleting group
+Removed role assignment from group 'platform-admins' (workspace: teamA)
+Group 'platform-admins' retains 2 role assignment(s) in other workspace(s) — group preserved
+```
 
 **Note:** For comprehensive API configuration management (services, routes, plugins at scale), use [decK](https://github.com/Kong/deck). kwot handles workspace-level plugin declarations; decK handles API-layer resource management.
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -320,7 +320,7 @@ func compareRoleDrift(rolesProcessor *roles.Processor, wsProcessor *workspace.Pr
 // compareGroupDrift compares configured groups with Kong to detect orphaned groups
 func compareGroupDrift(groupsProcessor *groups.Processor) error {
 	// Load configured groups
-	configuredGroups, err := groupsProcessor.LoadGroupConfig()
+	configuredGroups, err := groupsProcessor.LoadGroupConfig("all")
 	if err != nil {
 		return fmt.Errorf("failed to load group config: %w", err)
 	}

--- a/internal/groups/processor.go
+++ b/internal/groups/processor.go
@@ -343,7 +343,7 @@ func (p *Processor) GetAllGroups() ([]models.GroupResponse, error) {
 		allGroups = append(allGroups, response.Data...)
 
 		// Check if there are more pages
-		if response.Offset == "" || len(response.Data) < pageSize {
+		if len(response.Data) == 0 || response.Offset == "" || len(response.Data) < pageSize {
 			break
 		}
 

--- a/internal/groups/processor.go
+++ b/internal/groups/processor.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -211,8 +212,12 @@ func (p *Processor) loadGroupConfig(selectedWorkspace string) ([]models.GroupDet
 		return nil, fmt.Errorf("failed to read config directory: %w", err)
 	}
 
-	// Load global file once (may not exist)
-	globalGroups, _ := p.parseGroupConfigFile(filepath.Join(p.cfg.ConfigDir, groupConfigName))
+	// Load global file once — ignore only "not found"; surface parse/IO errors (#5)
+	globalPath := filepath.Join(p.cfg.ConfigDir, groupConfigName)
+	globalGroups, err := p.parseGroupConfigFile(globalPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to load global group config %s: %w", globalPath, err)
+	}
 
 	var allGroups []models.GroupDetail
 	workspacesWithLocalFile := make(map[string]bool)
@@ -233,18 +238,22 @@ func (p *Processor) loadGroupConfig(selectedWorkspace string) ([]models.GroupDet
 		}
 	}
 
-	// Include global entries for workspaces that don't have a local file
+	// Include global entries for workspaces that don't have a local file.
+	// If a global group maps roles to multiple workspaces, keep only the roles
+	// for workspaces that do NOT have a local file — don't drop the whole group (#1).
 	for _, g := range globalGroups {
-		hasLocalFile := false
+		var filteredRoles []models.GroupRole
 		for _, role := range g.Roles {
-			if workspacesWithLocalFile[role.Workspace] {
-				hasLocalFile = true
-				break
+			if !workspacesWithLocalFile[role.Workspace] {
+				filteredRoles = append(filteredRoles, role)
 			}
 		}
-		if !hasLocalFile {
-			allGroups = append(allGroups, g)
+		if len(filteredRoles) == 0 {
+			continue // all roles covered by local files
 		}
+		gCopy := g
+		gCopy.Roles = filteredRoles
+		allGroups = append(allGroups, gCopy)
 	}
 
 	if len(allGroups) == 0 {
@@ -258,15 +267,21 @@ func (p *Processor) loadGroupConfig(selectedWorkspace string) ([]models.GroupDet
 // preferring the workspace-local file over the global file.
 func (p *Processor) loadGroupConfigForWorkspace(workspace string) ([]models.GroupDetail, error) {
 	localPath := filepath.Join(p.cfg.ConfigDir, workspace, groupConfigName)
-	if _, err := os.Stat(localPath); err == nil {
+	switch _, err := os.Stat(localPath); {
+	case err == nil:
 		logger.Debugf("Using workspace-local %s for workspace %s", groupConfigName, workspace)
 		return p.parseGroupConfigFile(localPath)
+	case !errors.Is(err, os.ErrNotExist):
+		return nil, fmt.Errorf("failed to stat workspace-local %s for workspace %s: %w", groupConfigName, workspace, err)
 	}
 
 	globalPath := filepath.Join(p.cfg.ConfigDir, groupConfigName)
-	if _, err := os.Stat(globalPath); err == nil {
+	switch _, err := os.Stat(globalPath); {
+	case err == nil:
 		logger.Debugf("Using global %s for workspace %s", groupConfigName, workspace)
 		return p.parseGroupConfigFile(globalPath)
+	case !errors.Is(err, os.ErrNotExist):
+		return nil, fmt.Errorf("failed to stat global %s for workspace %s: %w", groupConfigName, workspace, err)
 	}
 
 	return nil, fmt.Errorf("no %s found in %s/ or config root", groupConfigName, workspace)

--- a/internal/groups/processor.go
+++ b/internal/groups/processor.go
@@ -228,14 +228,19 @@ func (p *Processor) loadGroupConfig(selectedWorkspace string) ([]models.GroupDet
 		}
 		wsName := entry.Name()
 		localPath := filepath.Join(p.cfg.ConfigDir, wsName, groupConfigName)
-		if _, statErr := os.Stat(localPath); statErr == nil {
-			groups, err := p.parseGroupConfigFile(localPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load groups for workspace %s: %w", wsName, err)
+		if _, statErr := os.Stat(localPath); statErr != nil {
+			if !errors.Is(statErr, os.ErrNotExist) {
+				return nil, fmt.Errorf("failed to stat local group config for workspace %s at %s: %w", wsName, localPath, statErr)
 			}
-			allGroups = append(allGroups, groups...)
-			workspacesWithLocalFile[wsName] = true
+			// No local file for this workspace; may fall back to global config.
+			continue
 		}
+		groups, err := p.parseGroupConfigFile(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load groups for workspace %s: %w", wsName, err)
+		}
+		allGroups = append(allGroups, groups...)
+		workspacesWithLocalFile[wsName] = true
 	}
 
 	// Include global entries for workspaces that don't have a local file.

--- a/internal/groups/processor.go
+++ b/internal/groups/processor.go
@@ -60,7 +60,7 @@ func (p *Processor) ProcessGroups(selectedWorkspace string) error {
 	logger.Debugf("Number of existing workspaces = %d", len(allWorkspaces))
 
 	// Load group configuration
-	groupConfig, err := p.loadGroupConfig()
+	groupConfig, err := p.loadGroupConfig(selectedWorkspace)
 	if err != nil {
 		return fmt.Errorf("failed to load group config: %w", err)
 	}
@@ -191,14 +191,93 @@ func (p *Processor) ProcessGroups(selectedWorkspace string) error {
 	return nil
 }
 
-// loadGroupConfig loads group configuration from YAML
+// loadGroupConfig loads group configuration from YAML.
+// Lookup precedence (workspace-local file takes priority over global):
+//   - For a specific workspace: <CONFIG_DIR>/<workspace>/groups-and-roles.yaml, then <CONFIG_DIR>/groups-and-roles.yaml
+//   - For "all": each workspace dir is checked for a local file; workspaces without one fall back to the global file
+//
+// Supports two YAML formats:
+// 1. Direct array: [- group_name: ..., - group_name: ...]
+// 2. Structured: role_info: {...}, config: [- group_name: ..., ...]
+func (p *Processor) loadGroupConfig(selectedWorkspace string) ([]models.GroupDetail, error) {
+	if selectedWorkspace != "all" {
+		return p.loadGroupConfigForWorkspace(selectedWorkspace)
+	}
+
+	// "all" mode: scan workspace subdirs, aggregate groups from local files;
+	// workspaces without a local file fall back to the global file.
+	entries, err := os.ReadDir(p.cfg.ConfigDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config directory: %w", err)
+	}
+
+	// Load global file once (may not exist)
+	globalGroups, _ := p.parseGroupConfigFile(filepath.Join(p.cfg.ConfigDir, groupConfigName))
+
+	var allGroups []models.GroupDetail
+	workspacesWithLocalFile := make(map[string]bool)
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wsName := entry.Name()
+		localPath := filepath.Join(p.cfg.ConfigDir, wsName, groupConfigName)
+		if _, statErr := os.Stat(localPath); statErr == nil {
+			groups, err := p.parseGroupConfigFile(localPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load groups for workspace %s: %w", wsName, err)
+			}
+			allGroups = append(allGroups, groups...)
+			workspacesWithLocalFile[wsName] = true
+		}
+	}
+
+	// Include global entries for workspaces that don't have a local file
+	for _, g := range globalGroups {
+		hasLocalFile := false
+		for _, role := range g.Roles {
+			if workspacesWithLocalFile[role.Workspace] {
+				hasLocalFile = true
+				break
+			}
+		}
+		if !hasLocalFile {
+			allGroups = append(allGroups, g)
+		}
+	}
+
+	if len(allGroups) == 0 {
+		return nil, fmt.Errorf("no %s found in workspace directories or config root", groupConfigName)
+	}
+
+	return allGroups, nil
+}
+
+// loadGroupConfigForWorkspace loads group config for a single workspace,
+// preferring the workspace-local file over the global file.
+func (p *Processor) loadGroupConfigForWorkspace(workspace string) ([]models.GroupDetail, error) {
+	localPath := filepath.Join(p.cfg.ConfigDir, workspace, groupConfigName)
+	if _, err := os.Stat(localPath); err == nil {
+		logger.Debugf("Using workspace-local %s for workspace %s", groupConfigName, workspace)
+		return p.parseGroupConfigFile(localPath)
+	}
+
+	globalPath := filepath.Join(p.cfg.ConfigDir, groupConfigName)
+	if _, err := os.Stat(globalPath); err == nil {
+		logger.Debugf("Using global %s for workspace %s", groupConfigName, workspace)
+		return p.parseGroupConfigFile(globalPath)
+	}
+
+	return nil, fmt.Errorf("no %s found in %s/ or config root", groupConfigName, workspace)
+}
+
+// parseGroupConfigFile reads and parses a groups-and-roles YAML file.
 // Supports two formats:
 // 1. Direct array: [- group_name: ..., - group_name: ...]
 // 2. Structured: role_info: {...}, config: [- group_name: ..., ...]
-func (p *Processor) loadGroupConfig() ([]models.GroupDetail, error) {
-	configPath := filepath.Join(p.cfg.ConfigDir, groupConfigName)
-
-	data, err := os.ReadFile(configPath)
+func (p *Processor) parseGroupConfigFile(path string) ([]models.GroupDetail, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read group config file: %w", err)
 	}
@@ -206,7 +285,6 @@ func (p *Processor) loadGroupConfig() ([]models.GroupDetail, error) {
 	// Try format 2 first (structured with role_info and config)
 	var wrapper models.GroupConfigWrapper
 	if err := yaml.Unmarshal(data, &wrapper); err == nil && len(wrapper.Config) > 0 {
-		// Successfully parsed as structured format
 		return wrapper.Config, nil
 	}
 
@@ -399,8 +477,8 @@ func (p *Processor) getRoleID(workspaceName, roleName string) (string, error) {
 }
 
 // LoadGroupConfig loads group configuration from file
-func (p *Processor) LoadGroupConfig() ([]models.GroupDetail, error) {
-	return p.loadGroupConfig()
+func (p *Processor) LoadGroupConfig(selectedWorkspace string) ([]models.GroupDetail, error) {
+	return p.loadGroupConfig(selectedWorkspace)
 }
 func (p *Processor) GetAllRolesForWorkspace(workspaceName string) ([]models.RoleResponse, error) {
 	var allRoles []models.RoleResponse

--- a/internal/groups/processor_test.go
+++ b/internal/groups/processor_test.go
@@ -1,0 +1,279 @@
+package groups
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Kong/kwot/internal/config"
+)
+
+// newTestProcessor creates a Processor using a temp dir as ConfigDir.
+// kong.Client is nil — loadGroupConfig never touches it.
+func newTestProcessor(t *testing.T, configDir string) *Processor {
+	t.Helper()
+	return &Processor{
+		client: nil,
+		cfg:    &config.Config{ConfigDir: configDir},
+		dryRun: false,
+	}
+}
+
+// writeFile creates a file at path with the given content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create dir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// --- YAML fixtures ---
+
+// directArrayYAML uses the flat list format (no role_info wrapper).
+const directArrayYAML = `
+- group_name: demo1-admin-group
+  group_comment: demo1 admin group
+  roles:
+    - workspace: demo1
+      role: admin
+- group_name: demo1-readonly-group
+  group_comment: demo1 readonly group
+  roles:
+    - workspace: demo1
+      role: readonlyrole
+`
+
+// structuredYAML uses the role_info + config wrapper format.
+const structuredYAML = `
+role_info:
+  wk_admin: admin
+  readonly_role: readonlyrole
+
+config:
+  - group_name: demo2-admin-group
+    group_comment: demo2 admin group
+    roles:
+      - workspace: demo2
+        role: admin
+  - group_name: demo2-readonly-group
+    group_comment: demo2 readonly group
+    roles:
+      - workspace: demo2
+        role: readonlyrole
+`
+
+const demo3YAML = `
+- group_name: demo3-admin-group
+  group_comment: demo3 admin group
+  roles:
+    - workspace: demo3
+      role: admin
+`
+
+const globalYAML = `
+- group_name: global-demo4-admin-group
+  group_comment: demo4 admin group (from global)
+  roles:
+    - workspace: demo4
+      role: admin
+- group_name: global-demo5-admin-group
+  group_comment: demo5 admin group (from global)
+  roles:
+    - workspace: demo5
+      role: admin
+`
+
+// --- Tests for specific workspace lookup ---
+
+func TestLoadGroupConfig_SpecificWorkspace_LocalFileTakesPriority(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	// Local file for demo1
+	writeFile(t, filepath.Join(dir, "demo1", groupConfigName), directArrayYAML)
+	// Global file also exists — should be ignored for demo1
+	writeFile(t, filepath.Join(dir, groupConfigName), globalYAML)
+
+	groups, err := p.loadGroupConfig("demo1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups from local file, got %d", len(groups))
+	}
+	if groups[0].GroupName != "demo1-admin-group" {
+		t.Errorf("expected demo1-admin-group, got %s", groups[0].GroupName)
+	}
+}
+
+func TestLoadGroupConfig_SpecificWorkspace_FallsBackToGlobal(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	// No local file for demo4 — only global exists
+	writeFile(t, filepath.Join(dir, groupConfigName), globalYAML)
+
+	groups, err := p.loadGroupConfig("demo4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups from global file, got %d", len(groups))
+	}
+}
+
+func TestLoadGroupConfig_SpecificWorkspace_NeitherFileExists(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	_, err := p.loadGroupConfig("demo1")
+	if err == nil {
+		t.Fatal("expected error when no config file exists, got nil")
+	}
+}
+
+// --- Tests for "all" mode ---
+
+func TestLoadGroupConfig_All_PerWorkspaceFilesOnly(t *testing.T) {
+	// Customer's setup: each workspace has its own groups-and-roles.yaml, no global file.
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	writeFile(t, filepath.Join(dir, "demo1", groupConfigName), directArrayYAML) // 2 groups
+	writeFile(t, filepath.Join(dir, "demo2", groupConfigName), structuredYAML)  // 2 groups
+	writeFile(t, filepath.Join(dir, "demo3", groupConfigName), demo3YAML)       // 1 group
+
+	groups, err := p.loadGroupConfig("all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 5 {
+		t.Fatalf("expected 5 groups total (2+2+1), got %d", len(groups))
+	}
+}
+
+func TestLoadGroupConfig_All_GlobalFileOnly(t *testing.T) {
+	// Existing users: only a global groups-and-roles.yaml, no per-workspace files.
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	// Workspace dirs exist but have no groups-and-roles.yaml
+	if err := os.MkdirAll(filepath.Join(dir, "demo4"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, groupConfigName), globalYAML)
+
+	groups, err := p.loadGroupConfig("all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups from global file, got %d", len(groups))
+	}
+}
+
+func TestLoadGroupConfig_All_MixedLocalAndGlobal(t *testing.T) {
+	// demo1 has a local file → uses local, ignores global entries for demo1.
+	// demo4 and demo5 have no local file → fall back to global entries.
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	writeFile(t, filepath.Join(dir, "demo1", groupConfigName), directArrayYAML) // 2 groups for demo1
+	writeFile(t, filepath.Join(dir, groupConfigName), globalYAML)               // 2 groups for demo4, demo5
+
+	// demo4 dir exists but no local groups file
+	if err := os.MkdirAll(filepath.Join(dir, "demo4"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := p.loadGroupConfig("all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 2 from demo1 local + 2 from global (demo4, demo5 — no local file for them)
+	if len(groups) != 4 {
+		t.Fatalf("expected 4 groups, got %d", len(groups))
+	}
+
+	// Verify global entries for demo1 are NOT included (local file takes precedence)
+	for _, g := range groups {
+		for _, r := range g.Roles {
+			if r.Workspace == "demo1" && g.GroupName != "demo1-admin-group" && g.GroupName != "demo1-readonly-group" {
+				t.Errorf("unexpected demo1 group from global file: %s", g.GroupName)
+			}
+		}
+	}
+}
+
+func TestLoadGroupConfig_All_NoFilesAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	_, err := p.loadGroupConfig("all")
+	if err == nil {
+		t.Fatal("expected error when no config files exist, got nil")
+	}
+}
+
+// --- Tests for YAML format parsing ---
+
+func TestParseGroupConfigFile_DirectArrayFormat(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	path := filepath.Join(dir, groupConfigName)
+	writeFile(t, path, directArrayYAML)
+
+	groups, err := p.parseGroupConfigFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].GroupName != "demo1-admin-group" {
+		t.Errorf("expected demo1-admin-group, got %s", groups[0].GroupName)
+	}
+	if groups[0].Roles[0].Workspace != "demo1" || groups[0].Roles[0].Role != "admin" {
+		t.Errorf("unexpected role assignment: %+v", groups[0].Roles[0])
+	}
+}
+
+func TestParseGroupConfigFile_StructuredFormat(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	path := filepath.Join(dir, groupConfigName)
+	writeFile(t, path, structuredYAML)
+
+	groups, err := p.parseGroupConfigFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].GroupName != "demo2-admin-group" {
+		t.Errorf("expected demo2-admin-group, got %s", groups[0].GroupName)
+	}
+}
+
+func TestParseGroupConfigFile_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	_, err := p.parseGroupConfigFile(filepath.Join(dir, "nonexistent.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/groups/processor_test.go
+++ b/internal/groups/processor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Kong/kwot/internal/config"
+	"github.com/Kong/kwot/internal/models"
 )
 
 // newTestProcessor creates a Processor using a temp dir as ConfigDir.
@@ -210,6 +211,61 @@ func TestLoadGroupConfig_All_MixedLocalAndGlobal(t *testing.T) {
 				t.Errorf("unexpected demo1 group from global file: %s", g.GroupName)
 			}
 		}
+	}
+}
+
+func TestLoadGroupConfig_All_MultiWorkspaceGroupInGlobal(t *testing.T) {
+	// Copilot review #1: a global group whose roles span multiple workspaces should
+	// not be dropped entirely when one of those workspaces has a local file.
+	// Only the roles for workspaces WITH a local file should be filtered out.
+	dir := t.TempDir()
+	p := newTestProcessor(t, dir)
+
+	// Global file has one group that maps roles to BOTH demo1 and demo4.
+	const multiWorkspaceGlobal = `
+- group_name: cross-workspace-group
+  group_comment: group with roles in demo1 and demo4
+  roles:
+    - workspace: demo1
+      role: admin
+    - workspace: demo4
+      role: readonlyrole
+`
+	writeFile(t, filepath.Join(dir, groupConfigName), multiWorkspaceGlobal)
+
+	// demo1 has a local file — its roles in the global group should be dropped.
+	// demo4 has no local file — its roles in the global group should be kept.
+	writeFile(t, filepath.Join(dir, "demo1", groupConfigName), directArrayYAML) // 2 groups for demo1
+	if err := os.MkdirAll(filepath.Join(dir, "demo4"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := p.loadGroupConfig("all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 2 from demo1 local + 1 cross-workspace-group (demo4 role only, demo1 role stripped)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	// Find cross-workspace-group and verify only the demo4 role survived
+	var crossGroup *models.GroupDetail
+	for i := range groups {
+		if groups[i].GroupName == "cross-workspace-group" {
+			crossGroup = &groups[i]
+			break
+		}
+	}
+	if crossGroup == nil {
+		t.Fatal("cross-workspace-group should be present (demo4 role not covered by local file)")
+	}
+	if len(crossGroup.Roles) != 1 {
+		t.Fatalf("expected 1 role (demo4 only), got %d: %+v", len(crossGroup.Roles), crossGroup.Roles)
+	}
+	if crossGroup.Roles[0].Workspace != "demo4" {
+		t.Errorf("expected remaining role for demo4, got workspace=%s", crossGroup.Roles[0].Workspace)
 	}
 }
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -40,6 +40,11 @@ func SetLevel(level LogLevel) {
 	currentLevel.Store(int32(level))
 }
 
+// IsDebugEnabled reports whether debug logging is active.
+func IsDebugEnabled() bool {
+	return getLogLevel() <= DebugLevel
+}
+
 // SetVerbose enables debug logging
 func SetVerbose(verbose bool) {
 	if verbose {

--- a/internal/roles/processor.go
+++ b/internal/roles/processor.go
@@ -41,11 +41,24 @@ func (p *Processor) ProcessRoles(selectedWorkspace, specificRole string) error {
 		return fmt.Errorf("failed to get workspace directories: %w", err)
 	}
 
+	// Validate that selected workspace exists in configuration
+	if selectedWorkspace != "all" {
+		found := false
+		for _, dir := range dirs {
+			if selectedWorkspace == dir {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("workspace '%s' not found in configuration", selectedWorkspace)
+		}
+	}
+
 	// Filter directories based on selection
 	var targetDirs []string
 	for _, dir := range dirs {
 		if selectedWorkspace != "all" && selectedWorkspace != dir {
-			logger.Warnf("Skipping workspace %s", dir)
 			continue
 		}
 		targetDirs = append(targetDirs, dir)

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -198,6 +198,7 @@ func (p *Processor) ApplyRBACUsersForWorkspaces(selectedWorkspace string) error 
 
 	if len(errorList) > 0 {
 		logger.Warnf("Completed RBAC user application with %d error(s)", len(errorList))
+		return fmt.Errorf("failed to apply RBAC users for %d workspace(s); first error: %w", len(errorList), errorList[0])
 	}
 
 	return nil
@@ -948,21 +949,38 @@ func (p *Processor) removeGroupRoleAssignmentsForWorkspace(workspaceName string,
 
 // getWorkspaceID retrieves the ID of a workspace by name
 func (p *Processor) getWorkspaceID(workspaceName string) (string, error) {
-	var result struct {
-		Data []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"data"`
-	}
+	pageSize := 1000
+	offset := ""
 
-	if err := p.client.GetJSON("/workspaces", nil, &result); err != nil {
-		return "", fmt.Errorf("failed to get workspaces: %w", err)
-	}
-
-	for _, ws := range result.Data {
-		if ws.Name == workspaceName {
-			return ws.ID, nil
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
 		}
+
+		var result struct {
+			Data []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON("/workspaces", params, &result); err != nil {
+			return "", fmt.Errorf("failed to get workspaces: %w", err)
+		}
+
+		for _, ws := range result.Data {
+			if ws.Name == workspaceName {
+				return ws.ID, nil
+			}
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+		offset = result.Offset
 	}
 
 	return "", fmt.Errorf("workspace %s not found", workspaceName)

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -611,10 +611,15 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 
 	if p.dryRun {
 		logger.Warnf("DRY-RUN: Would delete workspace %s (ID: %s) and all child resources", workspaceName, workspaceID)
+		logger.Warnf("DRY-RUN: Would also remove group-role assignments for workspace %s; groups that become empty would be deleted", workspaceName)
 		return nil
 	}
 
-	// Step 0: Remove group-role assignments that reference this workspace
+	// Step 0: Remove group-role assignments that reference this workspace.
+	// Groups are global in Kong — a group can hold roles across many workspaces.
+	// We remove only the role mappings that belong to this workspace.
+	// If a group ends up with no remaining role assignments it is deleted automatically.
+	// Groups that still have roles in other workspaces are left untouched.
 	logger.Infof("Step 0: Removing group-role assignments for workspace %s", workspaceName)
 	if err := p.removeGroupRoleAssignmentsForWorkspace(workspaceName, workspaceID); err != nil {
 		logger.Errorf("Failed to remove group-role assignments: %v", err)
@@ -750,10 +755,6 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 		logger.Errorf("Failed to delete key-sets in workspace %s: %v", workspaceName, err)
 	}
 
-	// Note: Do NOT auto-cleanup group role assignments
-	// Users must manually update groups-and-roles.yaml to maintain config integrity
-	logger.Warnf("Remember to remove references to workspace %s from groups-and-roles.yaml", workspaceName)
-
 	// Check for any remaining entities before attempting workspace deletion.
 	// Gated behind debug level to avoid unnecessary API calls on every deletion (#3).
 	if logger.IsDebugEnabled() {
@@ -842,7 +843,6 @@ func (p *Processor) removeGroupRoleAssignmentsForWorkspace(workspaceName string,
 
 	// Check each group for role assignments that reference this workspace
 	for _, group := range allGroups {
-		// Get all roles assigned to this group
 		rolesPath := fmt.Sprintf("/groups/%s/roles", group.ID)
 		var rolesResult struct {
 			Data []map[string]interface{} `json:"data"`
@@ -857,50 +857,66 @@ func (p *Processor) removeGroupRoleAssignmentsForWorkspace(workspaceName string,
 			continue
 		}
 
+		totalRoles := len(rolesResult.Data)
+		var rolesRemovedFromGroup int
+
 		// Delete any role assignments that reference this workspace
 		for _, roleAssignment := range rolesResult.Data {
-			// Extract workspace ID from nested object
 			ws, ok := roleAssignment["workspace"].(map[string]interface{})
 			if !ok {
 				continue
 			}
-
 			wsID, ok := ws["id"].(string)
 			if !ok || wsID != workspaceID {
 				continue
 			}
 
-			// Extract RBAC role ID from nested object
 			rbacRole, ok := roleAssignment["rbac_role"].(map[string]interface{})
 			if !ok {
 				continue
 			}
-
 			roleID, ok := rbacRole["id"].(string)
 			if !ok {
 				continue
 			}
 
-			// Delete the role assignment using query parameters
-			// No ID field exists, use workspace_id and rbac_role_id as identifiers
 			params := url.Values{}
 			params.Add("workspace_id", workspaceID)
 			params.Add("rbac_role_id", roleID)
 
-			rolesPath := fmt.Sprintf("/groups/%s/roles", group.ID)
 			if _, err := p.client.DELETEWithParams(rolesPath, params); err != nil {
 				logger.Errorf("Failed to delete role assignment from group %s: %v", group.Name, err)
 				continue
 			}
-			logger.Infof("Removed role assignment from group %s (workspace: %s)", group.Name, workspaceName)
+			logger.Infof("Removed role assignment from group '%s' (workspace: %s)", group.Name, workspaceName)
 			removedCount++
+			rolesRemovedFromGroup++
+		}
+
+		if rolesRemovedFromGroup == 0 {
+			continue
+		}
+
+		remainingRoles := totalRoles - rolesRemovedFromGroup
+		if remainingRoles == 0 {
+			// All role assignments belonged to this workspace — group is now empty, delete it
+			logger.Infof("Group '%s' has no remaining role assignments after workspace %s removal — deleting group", group.Name, workspaceName)
+			deletePath := fmt.Sprintf("/groups/%s", group.ID)
+			if _, err := p.client.DELETE(deletePath); err != nil {
+				logger.Errorf("Failed to delete empty group '%s': %v", group.Name, err)
+			} else {
+				logger.Infof("Deleted empty group '%s'", group.Name)
+			}
+		} else {
+			// Group still has role mappings in other workspaces — leave it
+			logger.Infof("Group '%s' retains %d role assignment(s) in other workspace(s) — group preserved", group.Name, remainingRoles)
 		}
 	}
 
 	if removedCount == 0 {
 		logger.Debugf("No group-role assignments found for workspace %s", workspaceName)
 	} else {
-		logger.Infof("Removed %d group-role assignments for workspace %s", removedCount, workspaceName)
+		logger.Infof("Removed %d group-role assignment(s) for workspace %s", removedCount, workspaceName)
 	}
 
 	return nil

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -755,8 +755,10 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 	logger.Warnf("Remember to remove references to workspace %s from groups-and-roles.yaml", workspaceName)
 
 	// Check for any remaining entities before attempting workspace deletion.
-	// Output is only visible with --verbose but is invaluable for diagnosing 400 errors.
-	p.debugLogRemainingEntities(workspaceName)
+	// Gated behind debug level to avoid unnecessary API calls on every deletion (#3).
+	if logger.IsDebugEnabled() {
+		p.debugLogRemainingEntities(workspaceName)
+	}
 
 	// Finally, delete the workspace itself using ID
 	path := fmt.Sprintf("/workspaces/%s", workspaceID)
@@ -2011,10 +2013,7 @@ func (p *Processor) countWorkspaceEntities(entityPath string) int {
 		}
 
 		if err := p.client.GetJSON(entityPath, params, &result); err != nil {
-			if total == 0 {
-				return -1 // endpoint unavailable or error on first page
-			}
-			break // partial count — stop here
+			return -1 // endpoint unavailable or paging error — count unreliable
 		}
 
 		total += len(result.Data)

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -738,17 +738,32 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 		logger.Errorf("Failed to delete RBAC users in workspace %s: %v", workspaceName, err)
 	}
 
+	// 16. Delete all keys (Kong Enterprise 3.1+)
+	logger.Infof("Step 16: Deleting keys from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspaceKeys(workspaceName); err != nil {
+		logger.Errorf("Failed to delete keys in workspace %s: %v", workspaceName, err)
+	}
+
+	// 17. Delete all key-sets (Kong Enterprise 3.1+)
+	logger.Infof("Step 17: Deleting key-sets from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspaceKeySets(workspaceName); err != nil {
+		logger.Errorf("Failed to delete key-sets in workspace %s: %v", workspaceName, err)
+	}
+
 	// Note: Do NOT auto-cleanup group role assignments
 	// Users must manually update groups-and-roles.yaml to maintain config integrity
 	logger.Warnf("Remember to remove references to workspace %s from groups-and-roles.yaml", workspaceName)
+
+	// Check for any remaining entities before attempting workspace deletion.
+	// Output is only visible with --verbose but is invaluable for diagnosing 400 errors.
+	p.debugLogRemainingEntities(workspaceName)
 
 	// Finally, delete the workspace itself using ID
 	path := fmt.Sprintf("/workspaces/%s", workspaceID)
 
 	resp, err := p.client.DELETE(path)
 	if err != nil {
-		// Try to provide more helpful error message
-		return fmt.Errorf("failed to delete workspace %s: %w\n  Make sure all child resources (services, routes, etc.) have been deleted first", workspaceName, err)
+		return fmt.Errorf("failed to delete workspace %s: %w -- workspace still has child resources that could not be removed; re-run with --verbose to see which entity types are still present", workspaceName, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -1870,6 +1885,199 @@ func (p *Processor) deleteAllWorkspaceCACertificates(workspaceName string) error
 	}
 
 	return nil
+}
+
+// deleteAllWorkspaceKeys deletes all keys from a workspace (Kong Enterprise 3.1+)
+func (p *Processor) deleteAllWorkspaceKeys(workspaceName string) error {
+	path := fmt.Sprintf("/%s/keys", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No keys endpoint or failed to get keys in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No keys found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d keys from workspace %s", len(result.Data), workspaceName)
+
+		for _, key := range result.Data {
+			keyPath := fmt.Sprintf("/%s/keys/%s", workspaceName, key.ID)
+			if _, err := p.client.DELETE(keyPath); err != nil {
+				logger.Errorf("Failed to delete key %s: %v", key.Name, err)
+				continue
+			}
+			logger.Infof("Deleted key %s from workspace %s", key.Name, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// deleteAllWorkspaceKeySets deletes all key-sets from a workspace (Kong Enterprise 3.1+)
+func (p *Processor) deleteAllWorkspaceKeySets(workspaceName string) error {
+	path := fmt.Sprintf("/%s/key-sets", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No key-sets endpoint or failed to get key-sets in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No key-sets found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d key-sets from workspace %s", len(result.Data), workspaceName)
+
+		for _, ks := range result.Data {
+			ksPath := fmt.Sprintf("/%s/key-sets/%s", workspaceName, ks.ID)
+			if _, err := p.client.DELETE(ksPath); err != nil {
+				logger.Errorf("Failed to delete key-set %s: %v", ks.Name, err)
+				continue
+			}
+			logger.Infof("Deleted key-set %s from workspace %s", ks.Name, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// countWorkspaceEntities paginates through all pages of a workspace entity endpoint
+// and returns the total count. Returns -1 if the endpoint could not be queried.
+func (p *Processor) countWorkspaceEntities(entityPath string) int {
+	pageSize := 1000
+	offset := ""
+	total := 0
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data   []interface{} `json:"data"`
+			Offset string        `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(entityPath, params, &result); err != nil {
+			if total == 0 {
+				return -1 // endpoint unavailable or error on first page
+			}
+			break // partial count — stop here
+		}
+
+		total += len(result.Data)
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return total
+}
+
+// debugLogRemainingEntities paginates all workspace-scoped entity types and logs
+// exact counts for any that are non-zero. Only visible with --verbose. Call this
+// before the final workspace DELETE to diagnose 400 errors.
+func (p *Processor) debugLogRemainingEntities(workspaceName string) {
+	entityTypes := []struct {
+		label string
+		path  string
+	}{
+		{"services", fmt.Sprintf("/%s/services", workspaceName)},
+		{"routes", fmt.Sprintf("/%s/routes", workspaceName)},
+		{"consumers", fmt.Sprintf("/%s/consumers", workspaceName)},
+		{"consumer_groups", fmt.Sprintf("/%s/consumer_groups", workspaceName)},
+		{"plugins", fmt.Sprintf("/%s/plugins", workspaceName)},
+		{"upstreams", fmt.Sprintf("/%s/upstreams", workspaceName)},
+		{"certificates", fmt.Sprintf("/%s/certificates", workspaceName)},
+		{"ca_certificates", fmt.Sprintf("/%s/ca_certificates", workspaceName)},
+		{"snis", fmt.Sprintf("/%s/snis", workspaceName)},
+		{"vaults", fmt.Sprintf("/%s/vaults", workspaceName)},
+		{"keys", fmt.Sprintf("/%s/keys", workspaceName)},
+		{"key-sets", fmt.Sprintf("/%s/key-sets", workspaceName)},
+		{"rbac/roles", fmt.Sprintf("/%s/rbac/roles", workspaceName)},
+		{"rbac/users", fmt.Sprintf("/%s/rbac/users", workspaceName)},
+	}
+
+	type entityCount struct {
+		label string
+		count int
+	}
+
+	var remaining []entityCount
+	for _, e := range entityTypes {
+		n := p.countWorkspaceEntities(e.path)
+		if n == -1 {
+			logger.Debugf("  [pre-delete check] could not query %s (endpoint unavailable or error)", e.label)
+			continue
+		}
+		if n > 0 {
+			remaining = append(remaining, entityCount{e.label, n})
+		}
+	}
+
+	if len(remaining) == 0 {
+		logger.Debugf("[pre-delete check] workspace %s: no remaining entities found", workspaceName)
+	} else {
+		logger.Debugf("[pre-delete check] workspace %s still has entities — workspace DELETE may return 400", workspaceName)
+		for _, e := range remaining {
+			logger.Debugf("  still present: %s (%d)", e.label, e.count)
+		}
+	}
 }
 
 // applyPlugins applies workspace plugins

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -665,94 +665,118 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 		logger.Errorf("Failed to delete mtls-auth credentials in workspace %s: %v", workspaceName, err)
 	}
 
-	// 3. Delete all services (which cascade to routes)
-	logger.Infof("Step 3: Deleting services from workspace %s", workspaceName)
+	// 3. Delete standalone DeGraphQL routes (service-scoped ones cascade with Step 4)
+	logger.Infof("Step 3: Deleting DeGraphQL routes from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspaceDeGraphQLRoutes(workspaceName); err != nil {
+		logger.Errorf("Failed to delete DeGraphQL routes in workspace %s: %v", workspaceName, err)
+	}
+
+	// 4. Delete all services (which cascade to routes and service-scoped degraphql_routes)
+	logger.Infof("Step 4: Deleting services from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceServices(workspaceName); err != nil {
 		logger.Errorf("Failed to delete services in workspace %s: %v", workspaceName, err)
 	}
 
-	// 4. Delete all routes (in case any are orphaned)
-	logger.Infof("Step 4: Deleting routes from workspace %s", workspaceName)
+	// 5. Delete all routes (in case any are orphaned)
+	logger.Infof("Step 5: Deleting routes from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceRoutes(workspaceName); err != nil {
 		logger.Errorf("Failed to delete routes in workspace %s: %v", workspaceName, err)
 	}
 
-	// 5. Delete all consumers
-	logger.Infof("Step 5: Deleting consumers from workspace %s", workspaceName)
+	// 6. Delete all consumers
+	logger.Infof("Step 6: Deleting consumers from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceConsumers(workspaceName); err != nil {
 		logger.Errorf("Failed to delete consumers in workspace %s: %v", workspaceName, err)
 	}
 
-	// 6. Delete all consumer groups
-	logger.Infof("Step 6: Deleting consumer groups from workspace %s", workspaceName)
+	// 7. Delete all consumer groups
+	logger.Infof("Step 7: Deleting consumer groups from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceConsumerGroups(workspaceName); err != nil {
 		logger.Errorf("Failed to delete consumer groups in workspace %s: %v", workspaceName, err)
 	}
 
-	// 7. Delete all upstreams
-	logger.Infof("Step 7: Deleting upstreams from workspace %s", workspaceName)
+	// 8. Delete all upstreams
+	logger.Infof("Step 8: Deleting upstreams from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceUpstreams(workspaceName); err != nil {
 		logger.Errorf("Failed to delete upstreams in workspace %s: %v", workspaceName, err)
 	}
 
-	// 8. Delete all certificates
-	logger.Infof("Step 8: Deleting certificates from workspace %s", workspaceName)
+	// 9. Delete all certificates
+	logger.Infof("Step 9: Deleting certificates from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceCertificates(workspaceName); err != nil {
 		logger.Errorf("Failed to delete certificates in workspace %s: %v", workspaceName, err)
 	}
 
-	// 9. Delete all CA certificates
-	logger.Infof("Step 9: Deleting CA certificates from workspace %s", workspaceName)
+	// 10. Delete all CA certificates
+	logger.Infof("Step 10: Deleting CA certificates from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceCACertificates(workspaceName); err != nil {
 		logger.Errorf("Failed to delete CA certificates in workspace %s: %v", workspaceName, err)
 	}
 
-	// 10. Delete all SNIs
-	logger.Infof("Step 10: Deleting SNIs from workspace %s", workspaceName)
+	// 11. Delete all SNIs
+	logger.Infof("Step 11: Deleting SNIs from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceSNIs(workspaceName); err != nil {
 		logger.Errorf("Failed to delete SNIs in workspace %s: %v", workspaceName, err)
 	}
 
-	// 11. Delete all vaults
-	logger.Infof("Step 11: Deleting vaults from workspace %s", workspaceName)
+	// 12. Delete all vaults
+	logger.Infof("Step 12: Deleting vaults from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceVaults(workspaceName); err != nil {
 		logger.Errorf("Failed to delete vaults in workspace %s: %v", workspaceName, err)
 	}
 
-	// 12. Delete all plugins in the workspace
-	logger.Infof("Step 12: Deleting plugins from workspace %s", workspaceName)
+	// 13. Delete all plugins in the workspace
+	logger.Infof("Step 13: Deleting plugins from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspacePlugins(workspaceName); err != nil {
 		logger.Errorf("Failed to delete plugins in workspace %s: %v", workspaceName, err)
 	}
 
-	// 13. Delete all roles in the workspace
-	logger.Infof("Step 13: Deleting roles from workspace %s", workspaceName)
+	// 14. Delete all custom plugin schemas in the workspace
+	logger.Infof("Step 14: Deleting custom plugins from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspaceCustomPlugins(workspaceName); err != nil {
+		logger.Errorf("Failed to delete custom plugins in workspace %s: %v", workspaceName, err)
+	}
+
+	// 15. Delete all roles in the workspace
+	logger.Infof("Step 15: Deleting roles from workspace %s", workspaceName)
 	if err := p.deleteWorkspaceRoles(workspaceName); err != nil {
 		logger.Errorf("Failed to delete roles in workspace %s: %v", workspaceName, err)
 	}
 
-	// 14. Delete all users in the workspace
-	logger.Infof("Step 14: Deleting users from workspace %s", workspaceName)
+	// 16. Delete all users in the workspace
+	logger.Infof("Step 16: Deleting users from workspace %s", workspaceName)
 	if err := p.deleteWorkspaceUsers(workspaceName); err != nil {
 		logger.Errorf("Failed to delete users in workspace %s: %v", workspaceName, err)
 	}
 
-	// 15. Delete all RBAC users in the workspace (workspace-scoped users)
-	logger.Infof("Step 15: Deleting RBAC users from workspace %s", workspaceName)
+	// 17. Delete all RBAC users in the workspace (workspace-scoped users)
+	logger.Infof("Step 17: Deleting RBAC users from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceRBACUsers(workspaceName); err != nil {
 		logger.Errorf("Failed to delete RBAC users in workspace %s: %v", workspaceName, err)
 	}
 
-	// 16. Delete all keys (Kong Enterprise 3.1+)
-	logger.Infof("Step 16: Deleting keys from workspace %s", workspaceName)
+	// 18. Delete all keys (Kong Enterprise 3.1+)
+	logger.Infof("Step 18: Deleting keys from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceKeys(workspaceName); err != nil {
 		logger.Errorf("Failed to delete keys in workspace %s: %v", workspaceName, err)
 	}
 
-	// 17. Delete all key-sets (Kong Enterprise 3.1+)
-	logger.Infof("Step 17: Deleting key-sets from workspace %s", workspaceName)
+	// 19. Delete all key-sets (Kong Enterprise 3.1+)
+	logger.Infof("Step 19: Deleting key-sets from workspace %s", workspaceName)
 	if err := p.deleteAllWorkspaceKeySets(workspaceName); err != nil {
 		logger.Errorf("Failed to delete key-sets in workspace %s: %v", workspaceName, err)
+	}
+
+	// 20. Delete all OIDC JWK sets (Kong Enterprise OIDC plugin)
+	logger.Infof("Step 20: Deleting OIDC JWK sets from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspaceOIDCJWKs(workspaceName); err != nil {
+		logger.Errorf("Failed to delete OIDC JWK sets in workspace %s: %v", workspaceName, err)
+	}
+
+	// 21. Delete all Dev Portal partials
+	logger.Infof("Step 21: Deleting Dev Portal partials from workspace %s", workspaceName)
+	if err := p.deleteAllWorkspacePartials(workspaceName); err != nil {
+		logger.Errorf("Failed to delete Dev Portal partials in workspace %s: %v", workspaceName, err)
 	}
 
 	// Check for any remaining entities before attempting workspace deletion.
@@ -1997,6 +2021,214 @@ func (p *Processor) deleteAllWorkspaceKeySets(workspaceName string) error {
 				continue
 			}
 			logger.Infof("Deleted key-set %s from workspace %s", ks.Name, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// deleteAllWorkspaceDeGraphQLRoutes deletes standalone DeGraphQL routes from a workspace.
+// Service-scoped degraphql_routes cascade-delete with their parent service (Step 4).
+func (p *Processor) deleteAllWorkspaceDeGraphQLRoutes(workspaceName string) error {
+	path := fmt.Sprintf("/%s/degraphql_routes", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID  string `json:"id"`
+				URI string `json:"uri"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No degraphql_routes endpoint or failed to get DeGraphQL routes in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No DeGraphQL routes found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d DeGraphQL routes from workspace %s", len(result.Data), workspaceName)
+
+		for _, route := range result.Data {
+			routePath := fmt.Sprintf("/%s/degraphql_routes/%s", workspaceName, route.ID)
+			if _, err := p.client.DELETE(routePath); err != nil {
+				logger.Errorf("Failed to delete DeGraphQL route %s: %v", route.ID, err)
+				continue
+			}
+			logger.Infof("Deleted DeGraphQL route %s from workspace %s", route.ID, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// deleteAllWorkspaceCustomPlugins deletes all custom plugin schemas from a workspace.
+func (p *Processor) deleteAllWorkspaceCustomPlugins(workspaceName string) error {
+	path := fmt.Sprintf("/%s/custom-plugins", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No custom-plugins endpoint or failed to get custom plugins in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No custom plugins found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d custom plugins from workspace %s", len(result.Data), workspaceName)
+
+		for _, plugin := range result.Data {
+			pluginPath := fmt.Sprintf("/%s/custom-plugins/%s", workspaceName, plugin.ID)
+			if _, err := p.client.DELETE(pluginPath); err != nil {
+				logger.Errorf("Failed to delete custom plugin %s: %v", plugin.Name, err)
+				continue
+			}
+			logger.Infof("Deleted custom plugin %s from workspace %s", plugin.Name, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// deleteAllWorkspaceOIDCJWKs deletes all OIDC JWK sets from a workspace.
+func (p *Processor) deleteAllWorkspaceOIDCJWKs(workspaceName string) error {
+	path := fmt.Sprintf("/%s/oic_jwks", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No oic_jwks endpoint or failed to get OIDC JWKs in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No OIDC JWK sets found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d OIDC JWK sets from workspace %s", len(result.Data), workspaceName)
+
+		for _, jwk := range result.Data {
+			jwkPath := fmt.Sprintf("/%s/oic_jwks/%s", workspaceName, jwk.ID)
+			if _, err := p.client.DELETE(jwkPath); err != nil {
+				logger.Errorf("Failed to delete OIDC JWK set %s: %v", jwk.ID, err)
+				continue
+			}
+			logger.Infof("Deleted OIDC JWK set %s from workspace %s", jwk.ID, workspaceName)
+		}
+
+		if result.Offset == "" || len(result.Data) < pageSize {
+			break
+		}
+
+		offset = result.Offset
+	}
+
+	return nil
+}
+
+// deleteAllWorkspacePartials deletes all Dev Portal partials from a workspace.
+func (p *Processor) deleteAllWorkspacePartials(workspaceName string) error {
+	path := fmt.Sprintf("/%s/partials", workspaceName)
+	pageSize := 1000
+	offset := ""
+
+	for {
+		params := url.Values{}
+		params.Add("size", strconv.Itoa(pageSize))
+		if offset != "" {
+			params.Add("offset", offset)
+		}
+
+		var result struct {
+			Data []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"data"`
+			Offset string `json:"offset"`
+		}
+
+		if err := p.client.GetJSON(path, params, &result); err != nil {
+			logger.Debugf("No partials endpoint or failed to get Dev Portal partials in workspace %s: %v", workspaceName, err)
+			return nil
+		}
+
+		if len(result.Data) == 0 {
+			logger.Debugf("No Dev Portal partials found in workspace %s", workspaceName)
+			break
+		}
+
+		logger.Infof("Deleting %d Dev Portal partials from workspace %s", len(result.Data), workspaceName)
+
+		for _, partial := range result.Data {
+			partialPath := fmt.Sprintf("/%s/partials/%s", workspaceName, partial.ID)
+			if _, err := p.client.DELETE(partialPath); err != nil {
+				logger.Errorf("Failed to delete Dev Portal partial %s: %v", partial.Name, err)
+				continue
+			}
+			logger.Infof("Deleted Dev Portal partial %s from workspace %s", partial.Name, workspaceName)
 		}
 
 		if result.Offset == "" || len(result.Data) < pageSize {


### PR DESCRIPTION
## Summary

- **Issue 1 — `groups-and-roles.yaml` per-workspace support:** Customers who place a `groups-and-roles.yaml` inside each workspace directory (instead of a single global file) were getting a file-not-found error. The groups processor now checks for a workspace-local file first and falls back to the global file, with full support for `apply all` mode by scanning and aggregating across all workspace dirs.
- **Issue 2 — Workspace deletion 400 on key-sets/keys:** Workspaces containing Kong Enterprise key-sets or keys (3.1+) would fail with a `400 Bad request` because those entity types were missing from the cleanup sequence. Added deletion steps for both, plus a pre-delete debug check (`--verbose`) that paginates all 14 entity types and logs exact counts so customers can see exactly what blocked deletion.

## Changes

### Issue 1 — Groups config lookup
- `internal/groups/processor.go` — `loadGroupConfig(selectedWorkspace)` checks `<CONFIG_DIR>/<workspace>/groups-and-roles.yaml` first, falls back to global; for `all` mode aggregates per-workspace files with global as fallback for workspaces that have none
- Extracted `parseGroupConfigFile` as single YAML parsing entry point (supports both direct array and `role_info`+`config` structured formats)
- `cmd/diff.go` — updated `LoadGroupConfig` call to pass `"all"`
- `internal/groups/processor_test.go` — 10 new unit tests covering all lookup scenarios (local-only, global-only, mixed, both formats, error cases)

### Issue 2 — Workspace deletion
- `internal/workspace/processor.go` — Step 16: delete all workspace keys; Step 17: delete all workspace key-sets
- `countWorkspaceEntities` helper with full pagination for accurate counts
- `debugLogRemainingEntities` runs before the final `DELETE /workspaces/{id}`; only visible with `--verbose`, logs exact entity counts per type to diagnose 400 errors
- Improved 400 error message directs users to `--verbose`

### Docs
- `README.md` — new "Group Configuration Layout" section documenting all three setup options (global, per-workspace, mixed)
- `CLAUDE.md` — updated file layout, lookup precedence, and editing guidance

## Test plan

- [ ] `make fmt && make lint && make test` — all pass
- [ ] `kwot apply` with per-workspace `groups-and-roles.yaml` files — groups loaded correctly per workspace
- [ ] `kwot apply` with global-only `groups-and-roles.yaml` — existing behaviour unchanged
- [ ] `kwot delete workspaces -n <name> --force` on workspace with key-sets — succeeds (previously 400)
- [ ] `kwot delete workspaces -n <name> --force --verbose` — pre-delete check logs entity counts
- [ ] Bug reproduced on stashed code (400), confirmed fixed after pop

🤖 Generated with [Claude Code](https://claude.com/claude-code)