### PR TITLE
feat: optional user_token field in workspace-rbac-user.yaml (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 - Optional `user_token` field in `workspace-rbac-user.yaml` — when set, kwot uses the provided value as the RBAC token for that user instead of generating a random UUID
   - Use case: CI pipelines, service accounts, or any scenario requiring a predictable pre-shared RBAC token
   - When omitted, existing behavior is preserved (a random UUID is generated at creation time and never stored)
-  - A debug log line confirms when a configured token is being used
+  - A debug log line confirms the configured token was used after a successful create
+  - **Note:** `user_token` is only applied on initial creation. If the user already exists (409), the token is **not** reconciled — the warning log will say `configured user_token was not applied` in that case; delete and recreate the user to change its token
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2026-04-05
+
+### Added
+
+- Optional `user_token` field in `workspace-rbac-user.yaml` — when set, kwot uses the provided value as the RBAC token for that user instead of generating a random UUID
+  - Use case: CI pipelines, service accounts, or any scenario requiring a predictable pre-shared RBAC token
+  - When omitted, existing behavior is preserved (a random UUID is generated at creation time and never stored)
+  - A debug log line confirms when a configured token is being used
+
+### Changed
+
+- `RBACUser` model now has `yaml:"user_token,omitempty"` tag so the field is correctly read from YAML config files
+
 ## [1.0.8] - 2026-04-01
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.8
+VERSION?=1.0.9
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go

--- a/README.md
+++ b/README.md
@@ -135,7 +135,13 @@ plugins:
 - name: workspace-admin-user
   roles:
     - admin
+- name: ci-pipeline-user
+  user_token: my-static-token   # optional — if omitted, a random UUID is generated
+  roles:
+    - workspace-admin
 ```
+
+The `user_token` field is **optional**. When set, kwot will use that value as the RBAC token for the user. When omitted, a random UUID is generated at creation time and not stored. Use a static token when you need a predictable, pre-shared secret (e.g. for CI pipelines or service accounts).
 
 ### `groups-and-roles.yaml`
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ plugins:
 - name: ci-pipeline-user
   user_token: my-static-token   # optional — if omitted, a random UUID is generated
   roles:
-    - workspace-admin
+    - admin
 ```
 
 The `user_token` field is **optional**. When set, kwot will use that value as the RBAC token for the user. When omitted, a random UUID is generated at creation time and not stored. Use a static token when you need a predictable, pre-shared secret (e.g. for CI pipelines or service accounts).

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -3,7 +3,7 @@ package models
 // RBACUser represents a workspace-scoped RBAC user
 type RBACUser struct {
 	Name      string   `yaml:"name" json:"name"`
-	UserToken string   `json:"user_token,omitempty"`
+	UserToken string   `yaml:"user_token,omitempty" json:"user_token,omitempty"`
 	Roles     []string `yaml:"roles" json:"roles"`
 }
 

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRBACUserYAMLUnmarshal(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantToken     string
+		wantUserName  string
+		wantRoleCount int
+	}{
+		{
+			name: "user with explicit token",
+			input: `
+name: test-user
+user_token: my-static-token
+roles:
+  - admin
+`,
+			wantToken:     "my-static-token",
+			wantUserName:  "test-user",
+			wantRoleCount: 1,
+		},
+		{
+			name: "user without token",
+			input: `
+name: test-user
+roles:
+  - admin
+  - readonlyrole
+`,
+			wantToken:     "",
+			wantUserName:  "test-user",
+			wantRoleCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u RBACUser
+			if err := yaml.Unmarshal([]byte(tt.input), &u); err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+			if u.Name != tt.wantUserName {
+				t.Errorf("Name = %q, want %q", u.Name, tt.wantUserName)
+			}
+			if u.UserToken != tt.wantToken {
+				t.Errorf("UserToken = %q, want %q", u.UserToken, tt.wantToken)
+			}
+			if len(u.Roles) != tt.wantRoleCount {
+				t.Errorf("len(Roles) = %d, want %d", len(u.Roles), tt.wantRoleCount)
+			}
+		})
+	}
+}

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -128,6 +128,58 @@ func TestValidateRoleName(t *testing.T) {
 	}
 }
 
+// TestValidateRBACUserConfig tests RBAC user configuration validation
+func TestValidateRBACUserConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   models.RBACUser
+		wantErr bool
+	}{
+		{
+			name: "valid user no token",
+			input: models.RBACUser{
+				Name:  "my-user",
+				Roles: []string{"admin"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid user with token",
+			input: models.RBACUser{
+				Name:      "my-user",
+				UserToken: "my-static-token",
+				Roles:     []string{"admin"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			input: models.RBACUser{
+				Name:  "",
+				Roles: []string{"admin"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no roles",
+			input: models.RBACUser{
+				Name:  "my-user",
+				Roles: []string{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRBACUserConfig(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRBACUserConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestValidateGroupConfig tests group configuration validation
 func TestValidateGroupConfig(t *testing.T) {
 	tests := []struct {

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -525,9 +525,13 @@ func (p *Processor) getCurrentRBACUsers(workspaceName string) ([]string, error) 
 // createOrUpdateRBACUser creates or updates an RBAC user
 // Matches Node.js approach: just POST and handle 409 conflict gracefully
 func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBACUser) error {
-	// Create user with UUID token
-	// Token is randomly generated (UUID) and NOT stored in config or logs
-	userToken := uuid.New().String()
+	// Use user-specified token if provided, otherwise generate a random UUID
+	userToken := user.UserToken
+	if userToken == "" {
+		userToken = uuid.New().String()
+	} else {
+		logger.Debugf("Using configured user_token for RBAC user '%s' in workspace '%s'", user.Name, workspaceName)
+	}
 
 	userData := map[string]string{
 		"name":       user.Name,
@@ -838,7 +842,6 @@ func (p *Processor) getWorkspaceID(workspaceName string) (string, error) {
 	return "", fmt.Errorf("workspace %s not found", workspaceName)
 }
 
-
 // GetWorkspaceDirs returns a list of workspace directories
 func (p *Processor) GetWorkspaceDirs() ([]string, error) {
 	entries, err := os.ReadDir(p.cfg.ConfigDir)
@@ -1007,7 +1010,6 @@ func (p *Processor) deletePlugin(workspaceName, pluginName string) error {
 	logger.Infof("Plugin %s deleted from workspace %s", pluginName, workspaceName)
 	return nil
 }
-
 
 // applyPlugins applies workspace plugins
 func (p *Processor) applyPlugins(workspaceName string, plugins []models.Plugin) error {

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -523,14 +523,15 @@ func (p *Processor) getCurrentRBACUsers(workspaceName string) ([]string, error) 
 }
 
 // createOrUpdateRBACUser creates or updates an RBAC user
-// Matches Node.js approach: just POST and handle 409 conflict gracefully
+// Matches Node.js approach: just POST and handle 409 conflict gracefully.
+// NOTE: user_token is only applied on initial creation. If the user already
+// exists (409), the configured token is NOT reconciled — Kong does not expose
+// a way to retrieve the existing token for comparison, so we leave it unchanged.
 func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBACUser) error {
 	// Use user-specified token if provided, otherwise generate a random UUID
 	userToken := user.UserToken
 	if userToken == "" {
 		userToken = uuid.New().String()
-	} else {
-		logger.Debugf("Using configured user_token for RBAC user '%s' in workspace '%s'", user.Name, workspaceName)
 	}
 
 	userData := map[string]string{
@@ -545,12 +546,19 @@ func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBA
 		if strings.Contains(errStr, "409") || strings.Contains(errStr, "conflict") ||
 			strings.Contains(errStr, "UNIQUE violation") || strings.Contains(errStr, "already exists") ||
 			strings.Contains(errStr, "Duplicate resource") {
-			logger.Warnf("RBAC user '%s' already exists in workspace '%s'", user.Name, workspaceName)
+			if user.UserToken != "" {
+				logger.Warnf("RBAC user '%s' already exists in workspace '%s' — configured user_token was not applied", user.Name, workspaceName)
+			} else {
+				logger.Warnf("RBAC user '%s' already exists in workspace '%s'", user.Name, workspaceName)
+			}
 			return nil
 		}
 		return fmt.Errorf("failed to create RBAC user: %w", err)
 	}
 
+	if user.UserToken != "" {
+		logger.Debugf("RBAC user '%s' created in workspace '%s' with configured user_token", user.Name, workspaceName)
+	}
 	logger.Infof("RBAC user '%s' created in workspace '%s'", user.Name, workspaceName)
 
 	// Verify RBAC user is available before assigning roles (with configurable retries)


### PR DESCRIPTION
Allow operators to specify a static RBAC token for a user via the `user_token` field in workspace-rbac-user.yaml. When the field is set, kwot sends that value to Kong instead of auto-generating a UUID. When omitted, existing random-UUID behavior is unchanged.

Useful for CI pipelines and service accounts that need a predictable, pre-shared token.

- Add yaml tag to RBACUser.UserToken so the field is read from YAML
- Update createOrUpdateRBACUser to use config token when present
- Add debug log when a configured token is used
- Add TestRBACUserYAMLUnmarshal and TestValidateRBACUserConfig tests
- Update README and CHANGELOG for v1.0.9
- Bump Makefile VERSION to 1.0.9