### PR TITLE
fix: upgrade Go toolchain to 1.26.2 to resolve 4 stdlib CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     labels: ["dependencies", "go"]
     commit-message:
       prefix: "deps:"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,9 +13,6 @@ permissions:
   contents: write
   packages: write
 
-env:
-  GO_VERSION: "1.24.12"
-
 jobs:
   # Detect version change from Makefile
   detect-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ permissions:
   contents: read
   checks: write
 
-env:
-  GO_VERSION: "1.26"
-
 jobs:
   # Run linting and static analysis
   lint:
@@ -22,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: golangci-lint
@@ -46,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Run tests with race detection
@@ -71,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Build binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Run vulnerability check with govulncheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.26"
   BINARY_NAME: kwot
 
 jobs:
@@ -51,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: golangci-lint
@@ -68,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Run tests with race detection
@@ -126,7 +125,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Build binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Install syft

--- a/.github/workflows/scheduled-security-scan.yml
+++ b/.github/workflows/scheduled-security-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           cache: true
 
       - name: Run govulncheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `go.mod` now pins `toolchain go1.26.2` as the single source of truth for the Go version
+- `go.mod` now declares `go 1.26` and pins `toolchain go1.26.2` for reproducible patch-level builds
 - All CI workflows (`ci.yml`, `release.yml`, `scheduled-security-scan.yml`) now use `go-version-file: go.mod` instead of a hardcoded version string — future Go upgrades only require a single change in `go.mod`
 - `Dockerfile` builder stage updated from `golang:1.24.12-alpine` to `golang:1.26.2-alpine`
 - `dependabot.yml` `open-pull-requests-limit` raised from 0 to 5 so Go module security patches are proposed automatically as PRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.10] - 2026-04-10
+
+### Security
+
+- Update Go toolchain from 1.26.1 to 1.26.2 to fix 4 Go standard library vulnerabilities:
+  - **GO-2026-4947**: Unexpected work during chain building in `crypto/x509`
+  - **GO-2026-4946**: Inefficient policy validation in `crypto/x509`
+  - **GO-2026-4870**: Unauthenticated TLS 1.3 KeyUpdate record causes DoS in `crypto/tls`
+  - **GO-2026-4866**: Case-sensitive `excludedSubtrees` name constraints auth bypass in `crypto/x509`
+
+### Changed
+
+- `go.mod` now pins `toolchain go1.26.2` as the single source of truth for the Go version
+- All CI workflows (`ci.yml`, `release.yml`, `scheduled-security-scan.yml`) now use `go-version-file: go.mod` instead of a hardcoded version string — future Go upgrades only require a single change in `go.mod`
+- `Dockerfile` builder stage updated from `golang:1.24.12-alpine` to `golang:1.26.2-alpine`
+- `dependabot.yml` `open-pull-requests-limit` raised from 0 to 5 so Go module security patches are proposed automatically as PRs
+
 ## [1.0.9] - 2026-04-05
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - use specific Go version for reproducibility and security
-FROM golang:1.24.12-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.9
+VERSION?=1.0.10
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/Kong/kwot
 
 go 1.26.2
 
+toolchain go1.26.2
+
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kong/kwot
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kong/kwot
 
-go 1.26.2
+go 1.26
 
 toolchain go1.26.2
 


### PR DESCRIPTION
Fixes GO-2026-4947, GO-2026-4946, GO-2026-4870, GO-2026-4866 in crypto/x509 and crypto/tls — all introduced in go1.26.1, fixed in go1.26.2.

Changes:
- go.mod: add 'toolchain go1.26.2' as single source of truth
- ci.yml, release.yml, scheduled-security-scan.yml: switch from hardcoded go-version to go-version-file: go.mod
- auto-release.yml: remove stale GO_VERSION env var (unused)
- Dockerfile: builder stage golang:1.24.12-alpine -> golang:1.26.2-alpine
- dependabot.yml: raise open-pull-requests-limit 0 -> 5 so patch upgrades arrive as reviewable PRs going forward

Verified: govulncheck reports 'No vulnerabilities found' on go1.26.2; all existing tests pass.

Closes #16