### PR TITLE
fix: configurable HTTP timeout and plugin retry for large multi-node …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ MAX_RETRY_ATTEMPTS=5
 
 # HTTP request timeout in seconds for all Kong Admin API calls
 # Default: 30 seconds
-# Increase this for large workspaces where cascade delete (DELETE /workspaces?cascade=true)
+# Increase this for large workspaces where cascade delete (DELETE /workspaces/{id}?cascade=true)
 # takes longer than the default — symptoms: "context deadline exceeded" on delete even
 # though Kong eventually returns 204 (the deletion did succeed on the server side).
 # Recommended for large deployments (500+ entities per workspace): 60–120

--- a/.env.example
+++ b/.env.example
@@ -132,13 +132,21 @@ MAX_CONCURRENT_WORKSPACES=5
 # Default: 5 attempts
 # Used for: workspace creation, role creation, RBAC user creation
 # Why: Handles Kong Enterprise replication lag where API returns 201 (created) but
-#      resource not yet available for immediate queries or dependent operations
-# Strategy: Linear backoff with intervals 50ms, 100ms, 150ms, 200ms, 250ms
-# Example scenarios:
-#   - Workspace created then plugins applied immediately (plugin creation fails with 404)
-#   - Role created then permissions applied immediately (permission assignment fails with 404)
-#   - RBAC user created then roles assigned immediately (role assignment fails with 404)
+#      resource not yet available for immediate queries or dependent operations.
+#      On large multi-node CP clusters, new workspace namespaces can take longer to
+#      propagate to all nodes; increase this if plugin/role creation fails with 404
+#      right after workspace creation.
+# Strategy for plugin retry: 200ms × attempt backoff (200ms, 400ms, 600ms, ...)
+# Strategy for workspace/user availability: linear 50ms × attempt
 MAX_RETRY_ATTEMPTS=5
+
+# HTTP request timeout in seconds for all Kong Admin API calls
+# Default: 30 seconds
+# Increase this for large workspaces where cascade delete (DELETE /workspaces?cascade=true)
+# takes longer than the default — symptoms: "context deadline exceeded" on delete even
+# though Kong eventually returns 204 (the deletion did succeed on the server side).
+# Recommended for large deployments (500+ entities per workspace): 60–120
+KONG_REQUEST_TIMEOUT=30
 
 # ============================================================================
 # PAGINATION (Automatic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.11] - 2026-04-15
+
+### Fixed
+
+- **Workspace deletion timeout on large deployments** — cascade delete (`DELETE /workspaces/{id}?cascade=true`) now respects the new `KONG_REQUEST_TIMEOUT` env var (default 30 s) instead of the previous hardcoded 10-second HTTP client timeout. On clusters with many entities per workspace the deletion was succeeding server-side (Kong returned HTTP 204) but kwot had already given up and reported `context deadline exceeded`. Increase `KONG_REQUEST_TIMEOUT` in `.env` to give Kong enough time (e.g. `120` for 500+ entity workspaces).
+- **Plugin 404 immediately after workspace creation on multi-node CP clusters** — on deployments with multiple Kong Control Plane nodes, a newly created workspace is written to the database immediately but CP nodes rebuild their routing cache asynchronously. Plugin POST requests load-balanced to a node whose cache has not yet caught up returned `404 Workspace not found` even though the workspace existed. kwot now retries plugin creation on 404 responses with a 200 ms × attempt backoff (controlled by `MAX_RETRY_ATTEMPTS`, default 5).
+- **Misleading error hint on delete timeout** — the error message for a timed-out cascade delete previously appended `"cascade=true requires Kong Gateway 3.4.0+; verify your Kong version"`, which was incorrect when the actual cause was a timeout. The message now distinguishes timeout errors and instructs the operator to raise `KONG_REQUEST_TIMEOUT`.
+
+### Added
+
+- New env var `KONG_REQUEST_TIMEOUT` (integer, seconds, default `30`) — configures the HTTP client timeout for all Kong Admin API calls. Previously hardcoded to 10 s; raising it is required for reliable cascade deletion of large workspaces.
+
+### Changed
+
+- `.env.example` and README updated to document `KONG_REQUEST_TIMEOUT` and the multi-node plugin retry behaviour.
+
 ## [1.0.10] - 2026-04-10
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.10
+VERSION?=1.0.11
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Place this at the config root (global) or inside a workspace folder (takes prior
 | `ADMIN_USER` + `BASE64_UID_PWD` | — | Credentials for PASSWORD auth |
 | `CONFIG_DIR` | `./config/` | Config files location |
 | `MAX_CONCURRENT_WORKSPACES` | `5` | Parallel workspace processing |
+| `MAX_RETRY_ATTEMPTS` | `5` | Retry attempts for resource availability checks after creation |
+| `KONG_REQUEST_TIMEOUT` | `30` | HTTP request timeout in seconds for all Kong Admin API calls. Increase for large workspaces where cascade delete takes longer than the default (symptoms: `context deadline exceeded` on delete). Recommended: `60`–`120` for 500+ entity workspaces. |
 
 ---
 
@@ -193,6 +195,24 @@ Place this at the config root (global) or inside a workspace folder (takes prior
 If a workspace has the Dev Portal enabled, it accumulates portal files (HTML pages, CSS, JS, images, email templates, YAML config). These are not visible in the standard entity counts shown by most Admin API endpoints, but they block workspace deletion.
 
 kwot uses `DELETE /workspaces/{id}?cascade=true` (Kong 3.4.0+) which removes the workspace and **all** its child resources — including Dev Portal files — in a single atomic operation. No manual pre-cleanup is needed.
+
+### Workspace deletion timeout on large deployments
+
+On Kong clusters with a large number of entities per workspace (hundreds of services, routes, plugins, RBAC users, etc.), the cascade delete can take more than the default 30-second HTTP timeout. Symptoms: `context deadline exceeded` error in kwot even though Kong eventually returns HTTP 204 (the deletion did succeed server-side).
+
+Set a longer timeout in `.env`:
+```
+KONG_REQUEST_TIMEOUT=120
+```
+
+### Plugin 404 immediately after workspace creation (multi-node CP)
+
+On multi-node Kong Control Plane clusters, a newly created workspace record is written to the database immediately, but each CP node rebuilds its internal routing cache asynchronously. If a plugin creation request is load-balanced to a node whose cache has not yet caught up, Kong returns `404 Workspace not found` even though the workspace exists.
+
+kwot retries plugin creation automatically on 404 responses using a backoff strategy (200 ms × attempt). The number of retries is controlled by `MAX_RETRY_ATTEMPTS` (default: `5`, giving up to ~3 seconds of retry window). Increase this on clusters where cache propagation is slow:
+```
+MAX_RETRY_ATTEMPTS=10
+```
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,7 +89,7 @@ func LoadConfig(configFile string) error {
 		cfg.MaxRetryAttempts = 5
 	}
 
-	// Ensure HTTPRequestTimeout is positive; 0 disables Go's HTTP client timeout entirely
+	// Ensure HTTPRequestTimeout is positive; non-positive values fall back to the default
 	if cfg.HTTPRequestTimeout <= 0 {
 		cfg.HTTPRequestTimeout = 30
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 
 	// Retry settings
 	MaxRetryAttempts int
+
+	// HTTP timeout settings
+	HTTPRequestTimeout int // seconds; used as the global HTTP client timeout
 }
 
 var globalConfig *Config
@@ -78,6 +81,7 @@ func LoadConfig(configFile string) error {
 
 		MaxConcurrentWorkspaces: getEnvInt("MAX_CONCURRENT_WORKSPACES", 5),
 		MaxRetryAttempts:        getEnvInt("MAX_RETRY_ATTEMPTS", 5),
+		HTTPRequestTimeout:      getEnvInt("KONG_REQUEST_TIMEOUT", 30),
 	}
 
 	// Ensure MaxRetryAttempts is positive; fall back to default if misconfigured

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,11 @@ func LoadConfig(configFile string) error {
 		cfg.MaxRetryAttempts = 5
 	}
 
+	// Ensure HTTPRequestTimeout is positive; 0 disables Go's HTTP client timeout entirely
+	if cfg.HTTPRequestTimeout <= 0 {
+		cfg.HTTPRequestTimeout = 30
+	}
+
 	// Validate required fields
 	if cfg.AuthMethod == "" {
 		return fmt.Errorf("ERROR: AUTH_METHOD not set\nMust be one of: RBAC or PASSWORD\nExample: export AUTH_METHOD=RBAC\nThen set corresponding credentials:\n  - For RBAC: export ADMIN_TOKEN=<token>\n  - For PASSWORD: export ADMIN_USER=<user> BASE64_UID_PWD=<base64_credentials>")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 )
 
@@ -45,9 +44,7 @@ func TestHTTPRequestTimeoutParsing(t *testing.T) {
 			if tt.envValue != "" {
 				t.Setenv("KONG_REQUEST_TIMEOUT", tt.envValue)
 			} else {
-				if err := os.Unsetenv("KONG_REQUEST_TIMEOUT"); err != nil {
-					t.Fatalf("os.Unsetenv failed: %v", err)
-				}
+				t.Setenv("KONG_REQUEST_TIMEOUT", "")
 			}
 			// Provide the minimum required env vars so LoadConfig doesn't error
 			t.Setenv("AUTH_METHOD", "RBAC")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestHTTPRequestTimeoutParsing verifies that KONG_REQUEST_TIMEOUT is read from the
+// environment and that the default/fallback behaviour is correct.
+func TestHTTPRequestTimeoutParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string // empty means unset
+		want     int
+	}{
+		{
+			name:     "explicit valid value",
+			envValue: "60",
+			want:     60,
+		},
+		{
+			name:     "unset uses default 30",
+			envValue: "",
+			want:     30,
+		},
+		{
+			name:     "zero falls back to default 30",
+			envValue: "0",
+			want:     30,
+		},
+		{
+			name:     "negative falls back to default 30",
+			envValue: "-5",
+			want:     30,
+		},
+		{
+			name:     "non-numeric falls back to default 30",
+			envValue: "notanumber",
+			want:     30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("KONG_REQUEST_TIMEOUT", tt.envValue)
+			} else {
+				if err := os.Unsetenv("KONG_REQUEST_TIMEOUT"); err != nil {
+					t.Fatalf("os.Unsetenv failed: %v", err)
+				}
+			}
+			// Provide the minimum required env vars so LoadConfig doesn't error
+			t.Setenv("AUTH_METHOD", "RBAC")
+			t.Setenv("ADMIN_TOKEN", "test-token")
+
+			if err := LoadConfig(""); err != nil {
+				t.Fatalf("LoadConfig() unexpected error: %v", err)
+			}
+			cfg := GetConfig()
+			if cfg.HTTPRequestTimeout != tt.want {
+				t.Errorf("HTTPRequestTimeout = %d, want %d (env=%q)", cfg.HTTPRequestTimeout, tt.want, tt.envValue)
+			}
+		})
+	}
+}
+
+// TestMaxRetryAttemptsDefaultFallback confirms the existing guard for MaxRetryAttempts
+// still works alongside the new HTTPRequestTimeout guard.
+func TestMaxRetryAttemptsDefaultFallback(t *testing.T) {
+	t.Setenv("MAX_RETRY_ATTEMPTS", "0")
+	t.Setenv("KONG_REQUEST_TIMEOUT", "0")
+	t.Setenv("AUTH_METHOD", "RBAC")
+	t.Setenv("ADMIN_TOKEN", "test-token")
+
+	if err := LoadConfig(""); err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+	cfg := GetConfig()
+	if cfg.MaxRetryAttempts != 5 {
+		t.Errorf("MaxRetryAttempts = %d, want 5 (fallback)", cfg.MaxRetryAttempts)
+	}
+	if cfg.HTTPRequestTimeout != 30 {
+		t.Errorf("HTTPRequestTimeout = %d, want 30 (fallback)", cfg.HTTPRequestTimeout)
+	}
+}

--- a/internal/kong/client.go
+++ b/internal/kong/client.go
@@ -65,7 +65,7 @@ func NewClient(cfg *config.Config) (*Client, error) {
 
 	httpClient := &http.Client{
 		Transport: transport,
-		Timeout:   10 * time.Second,
+		Timeout:   time.Duration(cfg.HTTPRequestTimeout) * time.Second,
 		// Disable automatic redirect following to capture cookies from /auth endpoint (PASSWORD auth)
 		// Kong Admin API does not use redirects for other endpoints, so this is safe globally
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/internal/kong/timeout_test.go
+++ b/internal/kong/timeout_test.go
@@ -1,0 +1,99 @@
+package kong
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Kong/kwot/internal/config"
+)
+
+// TestHTTPClientTimeoutDerivedFromConfig verifies that NewClient sets the HTTP
+// client timeout to the value in cfg.HTTPRequestTimeout, not a hardcoded value.
+func TestHTTPClientTimeoutDerivedFromConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredSecs  int
+		wantTimeout     time.Duration
+	}{
+		{
+			name:           "30 second timeout",
+			configuredSecs: 30,
+			wantTimeout:    30 * time.Second,
+		},
+		{
+			name:           "120 second timeout for large workspaces",
+			configuredSecs: 120,
+			wantTimeout:    120 * time.Second,
+		},
+		{
+			name:           "5 second timeout",
+			configuredSecs: 5,
+			wantTimeout:    5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			cfg := &config.Config{
+				KongAddr:           server.URL,
+				AuthMethod:         "RBAC",
+				AdminToken:         "test-token",
+				SSLVerify:          false,
+				MaxRetryAttempts:   5,
+				HTTPRequestTimeout: tt.configuredSecs,
+			}
+
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatalf("NewClient() failed: %v", err)
+			}
+
+			if client.HTTPClient.Timeout != tt.wantTimeout {
+				t.Errorf("HTTPClient.Timeout = %v, want %v", client.HTTPClient.Timeout, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+// TestHTTPClientTimeoutEnforced verifies that a request exceeding the configured
+// timeout is actually cancelled by the HTTP client.
+func TestHTTPClientTimeoutEnforced(t *testing.T) {
+	// Server that sleeps longer than the client timeout
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		KongAddr:           server.URL,
+		AuthMethod:         "RBAC",
+		AdminToken:         "test-token",
+		SSLVerify:          false,
+		MaxRetryAttempts:   5,
+		HTTPRequestTimeout: 1, // 1 second — well above 200 ms so normal requests pass
+	}
+
+	// Confirm a normal fast request works
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	// Force a 50 ms client timeout to trigger the deadline
+	client.HTTPClient.Timeout = 50 * time.Millisecond
+
+	_, err = client.GET("/status", nil)
+	if err == nil {
+		t.Error("Expected timeout error, got nil")
+	}
+}

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -640,6 +640,17 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 
 	resp, err := p.client.DELETEWithParams(workspacePath, cascadeParams)
 	if err != nil {
+		errStr := err.Error()
+		// A timeout means Kong is still processing the cascade delete (large workspace).
+		// Increase KONG_REQUEST_TIMEOUT in .env to give Kong more time.
+		if strings.Contains(errStr, "context deadline exceeded") || strings.Contains(errStr, "timeout") {
+			return fmt.Errorf(
+				"failed to delete workspace %s (path: %s): %w -- "+
+					"the request timed out; the workspace may have too many entities for the current KONG_REQUEST_TIMEOUT (%d s). "+
+					"Increase KONG_REQUEST_TIMEOUT in .env and retry",
+				workspaceName, workspacePath, err, p.cfg.HTTPRequestTimeout,
+			)
+		}
 		return fmt.Errorf(
 			"failed to delete workspace %s (path: %s): %w -- "+
 				"cascade=true requires Kong Gateway 3.4.0+; verify your Kong version and that the workspace exists",
@@ -1071,7 +1082,12 @@ func (p *Processor) applyPlugins(workspaceName string, plugins []models.Plugin) 
 	return nil
 }
 
-// applyPlugin applies a single plugin to a workspace
+// applyPlugin applies a single plugin to a workspace.
+// On large Kong deployments with multiple CP nodes the workspace namespace may not
+// yet be initialised on every node right after creation.  Requests are load-balanced
+// across nodes, so a POST that lands on a node whose cache has not caught up yet
+// returns 404 "Workspace not found" even though GET /workspaces/{name} already
+// succeeded on a different node.  We retry with backoff on those transient 404s.
 func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) error {
 	if p.dryRun {
 		logger.Infof("[DRY-RUN] Would create plugin %s in workspace %s", plugin.Name, workspaceName)
@@ -1080,7 +1096,6 @@ func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) erro
 
 	logger.Infof("Attempting to create plugin %s in workspace %s", plugin.Name, workspaceName)
 
-	// Create plugin in the workspace
 	payload := map[string]interface{}{
 		"name":   plugin.Name,
 		"config": plugin.Config,
@@ -1088,18 +1103,45 @@ func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) erro
 
 	path := fmt.Sprintf("/%s/plugins", workspaceName)
 	logger.Debugf("Creating plugin at path: %s with payload: %+v", path, payload)
-	var result map[string]interface{}
-	if err := p.client.PostJSON(path, payload, &result); err != nil {
-		// If plugin already exists (409 UNIQUE violation), just log it as info and continue
+
+	maxAttempts := p.cfg.MaxRetryAttempts
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var result map[string]interface{}
+		err := p.client.PostJSON(path, payload, &result)
+		if err == nil {
+			logger.Infof("Plugin %s created in workspace %s", plugin.Name, workspaceName)
+			return nil
+		}
+
 		errStr := err.Error()
+
+		// Plugin already exists — idempotent, not an error.
 		if strings.Contains(errStr, "409") || strings.Contains(errStr, "UNIQUE violation") || strings.Contains(errStr, "already exists") {
 			logger.Infof("Plugin %s already exists in workspace %s", plugin.Name, workspaceName)
 			return nil
 		}
+
+		// Workspace namespace not yet ready on this Kong CP node — retry with backoff.
+		// This happens on multi-node CP clusters when the new workspace record has been
+		// committed to the DB but not all nodes have rebuilt their router cache yet.
+		if strings.Contains(errStr, "not found") || strings.Contains(errStr, "404") {
+			lastErr = err
+			if attempt < maxAttempts {
+				backoff := time.Duration(attempt*200) * time.Millisecond
+				logger.Debugf("Workspace %s not ready on Kong node for plugin %s (attempt %d/%d), retrying in %v", workspaceName, plugin.Name, attempt, maxAttempts, backoff)
+				time.Sleep(backoff)
+				continue
+			}
+			logger.Errorf("Failed to create plugin %s in workspace %s after %d attempts: %v", plugin.Name, workspaceName, maxAttempts, lastErr)
+			return fmt.Errorf("failed to create plugin %s after %d attempts: %w", plugin.Name, maxAttempts, lastErr)
+		}
+
+		// Any other error — fail immediately.
 		logger.Errorf("Failed to create plugin %s in workspace %s: %v", plugin.Name, workspaceName, err)
 		return fmt.Errorf("failed to create plugin %s: %w", plugin.Name, err)
 	}
 
-	logger.Infof("Plugin %s created in workspace %s", plugin.Name, workspaceName)
-	return nil
+	logger.Errorf("Failed to create plugin %s in workspace %s after %d attempts: %v", plugin.Name, workspaceName, maxAttempts, lastErr)
+	return fmt.Errorf("failed to create plugin %s after %d attempts: %w", plugin.Name, maxAttempts, lastErr)
 }

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -1125,7 +1125,12 @@ func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) erro
 		// Workspace namespace not yet ready on this Kong CP node — retry with backoff.
 		// This happens on multi-node CP clusters when the new workspace record has been
 		// committed to the DB but not all nodes have rebuilt their router cache yet.
-		if strings.Contains(errStr, "not found") || strings.Contains(errStr, "404") {
+		// We intentionally narrow this to workspace-specific 404s ("Workspace ... not found")
+		// to avoid retrying on permanent 404s (wrong workspace name, unsupported endpoint, etc.)
+		// which would only add delay and mask the real root cause.
+		isWorkspaceNotReady := strings.Contains(errStr, "not found") &&
+			strings.Contains(strings.ToLower(errStr), "workspace")
+		if isWorkspaceNotReady {
 			lastErr = err
 			if attempt < maxAttempts {
 				backoff := time.Duration(attempt*200) * time.Millisecond

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -1,7 +1,10 @@
 package workspace
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -640,10 +643,16 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 
 	resp, err := p.client.DELETEWithParams(workspacePath, cascadeParams)
 	if err != nil {
-		errStr := err.Error()
-		// A timeout means Kong is still processing the cascade delete (large workspace).
-		// Increase KONG_REQUEST_TIMEOUT in .env to give Kong more time.
-		if strings.Contains(errStr, "context deadline exceeded") || strings.Contains(errStr, "timeout") {
+		// Use structured checks for timeout rather than string matching, which is
+		// fragile across Go versions and transport implementations.
+		isTimeout := errors.Is(err, context.DeadlineExceeded)
+		if !isTimeout {
+			var netErr net.Error
+			if errors.As(err, &netErr) {
+				isTimeout = netErr.Timeout()
+			}
+		}
+		if isTimeout {
 			return fmt.Errorf(
 				"failed to delete workspace %s (path: %s): %w -- "+
 					"the request timed out; the workspace may have too many entities for the current KONG_REQUEST_TIMEOUT (%d s). "+
@@ -1130,23 +1139,21 @@ func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) erro
 		// which would only add delay and mask the real root cause.
 		isWorkspaceNotReady := strings.Contains(errStr, "not found") &&
 			strings.Contains(strings.ToLower(errStr), "workspace")
-		if isWorkspaceNotReady {
-			lastErr = err
-			if attempt < maxAttempts {
-				backoff := time.Duration(attempt*200) * time.Millisecond
-				logger.Debugf("Workspace %s not ready on Kong node for plugin %s (attempt %d/%d), retrying in %v", workspaceName, plugin.Name, attempt, maxAttempts, backoff)
-				time.Sleep(backoff)
-				continue
-			}
-			logger.Errorf("Failed to create plugin %s in workspace %s after %d attempts: %v", plugin.Name, workspaceName, maxAttempts, lastErr)
-			return fmt.Errorf("failed to create plugin %s after %d attempts: %w", plugin.Name, maxAttempts, lastErr)
+		if !isWorkspaceNotReady {
+			// Permanent error — fail immediately without retrying.
+			logger.Errorf("Failed to create plugin %s in workspace %s: %v", plugin.Name, workspaceName, err)
+			return fmt.Errorf("failed to create plugin %s: %w", plugin.Name, err)
 		}
 
-		// Any other error — fail immediately.
-		logger.Errorf("Failed to create plugin %s in workspace %s: %v", plugin.Name, workspaceName, err)
-		return fmt.Errorf("failed to create plugin %s: %w", plugin.Name, err)
+		lastErr = err
+		if attempt < maxAttempts {
+			backoff := time.Duration(attempt*200) * time.Millisecond
+			logger.Debugf("Workspace %s not ready on Kong node for plugin %s (attempt %d/%d), retrying in %v", workspaceName, plugin.Name, attempt, maxAttempts, backoff)
+			time.Sleep(backoff)
+		}
 	}
 
+	// All retry attempts exhausted — workspace namespace did not become ready in time.
 	logger.Errorf("Failed to create plugin %s in workspace %s after %d attempts: %v", plugin.Name, workspaceName, maxAttempts, lastErr)
 	return fmt.Errorf("failed to create plugin %s after %d attempts: %w", plugin.Name, maxAttempts, lastErr)
 }

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -656,7 +656,7 @@ func (p *Processor) DeleteWorkspace(workspaceName string) error {
 			return fmt.Errorf(
 				"failed to delete workspace %s (path: %s): %w -- "+
 					"the request timed out; the workspace may have too many entities for the current KONG_REQUEST_TIMEOUT (%d s). "+
-					"Increase KONG_REQUEST_TIMEOUT in .env and retry",
+					"Increase KONG_REQUEST_TIMEOUT in your environment (or .env) and retry",
 				workspaceName, workspacePath, err, p.cfg.HTTPRequestTimeout,
 			)
 		}
@@ -1114,6 +1114,9 @@ func (p *Processor) applyPlugin(workspaceName string, plugin models.Plugin) erro
 	logger.Debugf("Creating plugin at path: %s with payload: %+v", path, payload)
 
 	maxAttempts := p.cfg.MaxRetryAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		var result map[string]interface{}

--- a/internal/workspace/processor_test.go
+++ b/internal/workspace/processor_test.go
@@ -51,6 +51,18 @@ func workspaceListHandler(wsName, wsID string, deleteFn func(w http.ResponseWrit
 			return
 		}
 		if r.Method == http.MethodDelete {
+			// Assert the expected path and cascade=true param are present
+			expectedPath := "/workspaces/" + wsID
+			if r.URL.Path != expectedPath {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"unexpected delete path: ` + r.URL.Path + `"}`))
+				return
+			}
+			if r.URL.Query().Get("cascade") != "true" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"message":"missing cascade=true"}`))
+				return
+			}
 			deleteFn(w, r)
 			return
 		}
@@ -112,10 +124,13 @@ func TestDeleteWorkspace_NonTimeoutErrorMessage(t *testing.T) {
 // TestApplyPlugin_SuccessOnFirstAttempt verifies the happy path.
 func TestApplyPlugin_SuccessOnFirstAttempt(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
+		if r.Method == http.MethodPost && r.URL.Path == "/test-ws/plugins" {
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":"plug-1","name":"key-auth"}`))
+			return
 		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"unexpected request"}`))
 	})
 
 	proc, server := newTestProcessor(t, handler, 30, 5)
@@ -129,8 +144,13 @@ func TestApplyPlugin_SuccessOnFirstAttempt(t *testing.T) {
 // TestApplyPlugin_IdempotentOn409 verifies that a 409 conflict is not an error.
 func TestApplyPlugin_IdempotentOn409(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusConflict)
-		_, _ = w.Write([]byte(`{"message":"UNIQUE violation"}`))
+		if r.Method == http.MethodPost && r.URL.Path == "/test-ws/plugins" {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"message":"UNIQUE violation"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"unexpected request"}`))
 	})
 
 	proc, server := newTestProcessor(t, handler, 30, 5)

--- a/internal/workspace/processor_test.go
+++ b/internal/workspace/processor_test.go
@@ -1,0 +1,250 @@
+package workspace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Kong/kwot/internal/config"
+	"github.com/Kong/kwot/internal/kong"
+	"github.com/Kong/kwot/internal/models"
+)
+
+// newTestProcessor creates a Processor backed by a mock HTTP server for unit tests.
+func newTestProcessor(t *testing.T, handler http.HandlerFunc, timeoutSecs int, maxRetry int) (*Processor, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	cfg := &config.Config{
+		KongAddr:           server.URL,
+		AuthMethod:         "RBAC",
+		AdminToken:         "test-token",
+		SSLVerify:          false,
+		MaxRetryAttempts:   maxRetry,
+		HTTPRequestTimeout: timeoutSecs,
+	}
+	client, err := kong.NewClient(cfg)
+	if err != nil {
+		server.Close()
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	return NewProcessor(client, cfg, false), server
+}
+
+func pluginFixture(name string) models.Plugin {
+	return models.Plugin{Name: name, Config: map[string]interface{}{}}
+}
+
+// ── DeleteWorkspace — timeout vs. non-timeout error messages ─────────────────
+
+// workspaceListHandler returns an http.HandlerFunc that serves getWorkspaceID's
+// paginated GET /workspaces call, returning wsID for wsName, then delegates
+// DELETE requests to the provided deleteFn.
+func workspaceListHandler(wsName, wsID string, deleteFn func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/workspaces" {
+			// Respond to getWorkspaceID pagination call
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[{"id":"` + wsID + `","name":"` + wsName + `"}],"offset":""}`))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			deleteFn(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// TestDeleteWorkspace_TimeoutErrorMessage verifies that when the cascade DELETE
+// times out the error tells the operator to raise KONG_REQUEST_TIMEOUT and does
+// NOT produce the misleading "check Kong version" hint.
+func TestDeleteWorkspace_TimeoutErrorMessage(t *testing.T) {
+	handler := workspaceListHandler("test-ws", "abc-123", func(w http.ResponseWriter, r *http.Request) {
+		// Simulate Kong still processing — sleep beyond client timeout
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	// Override to a tiny timeout to trigger context.DeadlineExceeded
+	proc.client.HTTPClient.Timeout = 50 * time.Millisecond
+
+	err := proc.DeleteWorkspace("test-ws")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "KONG_REQUEST_TIMEOUT") {
+		t.Errorf("timeout error should mention KONG_REQUEST_TIMEOUT, got: %s", errMsg)
+	}
+	if strings.Contains(errMsg, "cascade=true requires Kong Gateway") {
+		t.Errorf("timeout error must not include Kong version hint, got: %s", errMsg)
+	}
+}
+
+// TestDeleteWorkspace_NonTimeoutErrorMessage verifies that a non-timeout error
+// (e.g. 404) still returns the cascade / Kong-version hint.
+func TestDeleteWorkspace_NonTimeoutErrorMessage(t *testing.T) {
+	handler := workspaceListHandler("test-ws", "abc-123", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"workspace not found"}`))
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	err := proc.DeleteWorkspace("test-ws")
+	if err == nil {
+		t.Fatal("expected error for 404 delete, got nil")
+	}
+	if !strings.Contains(err.Error(), "cascade=true requires Kong Gateway") {
+		t.Errorf("non-timeout error should contain cascade hint, got: %s", err.Error())
+	}
+}
+
+// ── applyPlugin — retry logic ─────────────────────────────────────────────────
+
+// TestApplyPlugin_SuccessOnFirstAttempt verifies the happy path.
+func TestApplyPlugin_SuccessOnFirstAttempt(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"plug-1","name":"key-auth"}`))
+		}
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	if err := proc.applyPlugin("test-ws", pluginFixture("key-auth")); err != nil {
+		t.Errorf("expected success, got: %v", err)
+	}
+}
+
+// TestApplyPlugin_IdempotentOn409 verifies that a 409 conflict is not an error.
+func TestApplyPlugin_IdempotentOn409(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"UNIQUE violation"}`))
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	if err := proc.applyPlugin("test-ws", pluginFixture("key-auth")); err != nil {
+		t.Errorf("409 should be treated as success (idempotent), got: %v", err)
+	}
+}
+
+// TestApplyPlugin_RetriesOnTransientWorkspaceNotFound verifies that a 404
+// "Workspace ... not found" triggers retries and succeeds once the node is ready.
+func TestApplyPlugin_RetriesOnTransientWorkspaceNotFound(t *testing.T) {
+	var callCount int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			n := atomic.AddInt32(&callCount, 1)
+			if n < 3 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Workspace 'test-ws' not found"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"plug-1","name":"key-auth"}`))
+		}
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	if err := proc.applyPlugin("test-ws", pluginFixture("key-auth")); err != nil {
+		t.Errorf("expected success after retries, got: %v", err)
+	}
+	if callCount < 3 {
+		t.Errorf("expected at least 3 POST attempts, got %d", callCount)
+	}
+}
+
+// TestApplyPlugin_ExhaustsRetriesOnPersistentWorkspaceNotFound verifies that
+// after MaxRetryAttempts the function returns a descriptive error.
+func TestApplyPlugin_ExhaustsRetriesOnPersistentWorkspaceNotFound(t *testing.T) {
+	var callCount int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			atomic.AddInt32(&callCount, 1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Workspace 'test-ws' not found"}`))
+		}
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 3)
+	defer server.Close()
+
+	err := proc.applyPlugin("test-ws", pluginFixture("key-auth"))
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if !strings.Contains(err.Error(), "3 attempts") {
+		t.Errorf("error should mention attempt count, got: %v", err)
+	}
+	if int(callCount) != 3 {
+		t.Errorf("expected exactly 3 POST calls (MaxRetryAttempts), got %d", callCount)
+	}
+}
+
+// TestApplyPlugin_PermanentErrorNotRetried verifies that a non-workspace error
+// (e.g. 400 schema violation) fails immediately without any retry.
+func TestApplyPlugin_PermanentErrorNotRetried(t *testing.T) {
+	var callCount int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			atomic.AddInt32(&callCount, 1)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"message":"schema violation: unknown field"}`))
+		}
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	err := proc.applyPlugin("test-ws", pluginFixture("key-auth"))
+	if err == nil {
+		t.Error("expected error for permanent 400, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("permanent error should not retry: expected 1 call, got %d", callCount)
+	}
+}
+
+// TestApplyPlugin_NonWorkspace404NotRetried verifies that a 404 whose message
+// does NOT mention "workspace" is treated as permanent and not retried.
+func TestApplyPlugin_NonWorkspace404NotRetried(t *testing.T) {
+	var callCount int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			atomic.AddInt32(&callCount, 1)
+			w.WriteHeader(http.StatusNotFound)
+			// "endpoint not found" — no "workspace" keyword
+			_, _ = w.Write([]byte(`{"message":"endpoint not found"}`))
+		}
+	})
+
+	proc, server := newTestProcessor(t, handler, 30, 5)
+	defer server.Close()
+
+	err := proc.applyPlugin("test-ws", pluginFixture("key-auth"))
+	if err == nil {
+		t.Error("expected error for permanent 404, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("non-workspace 404 must not retry: expected 1 call, got %d", callCount)
+	}
+}


### PR DESCRIPTION
…Kong deployments

Two race conditions affecting large Kong CP deployments with many entities:

1. Workspace cascade delete timed out after the hardcoded 10-second HTTP client timeout, even though Kong eventually returned 204 (deletion succeeded server-side). Introduces KONG_REQUEST_TIMEOUT env var (default 30 s) to make the timeout configurable; raises the default from 10 s to 30 s and improves the timeout error message to guide operators rather than suggesting a false Kong version mismatch.

2. Plugin creation returned 404 "Workspace not found" immediately after workspace creation on multi-node CP clusters, because CP nodes rebuild their routing cache asynchronously. Adds a retry loop in applyPlugin with 200 ms × attempt backoff (respects MAX_RETRY_ATTEMPTS) so kwot waits for the workspace namespace to propagate to all nodes before failing.