### PR TITLE
fix(security): upgrade Go toolchain to go1.26.3 — fixes GO-2026-4971 and GO-2026-4918

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.12] - 2026-05-26
+
+### Security
+
+- Update Go toolchain from `go1.26.2` to `go1.26.3` to fix 2 Go standard library vulnerabilities (closes #24):
+  - **GO-2026-4971**: Panic in `Dial` and `LookupPort` when handling NUL byte on Windows in `net`
+  - **GO-2026-4918**: Infinite loop in HTTP/2 transport when given bad `SETTINGS_MAX_FRAME_SIZE` in `net/http`
+
+### Changed
+
+- `go.mod` toolchain pin updated from `go1.26.2` to `go1.26.3`
+- `Dockerfile` builder stage updated from `golang:1.26.2-alpine` to `golang:1.26.3-alpine`
+
 ## [1.0.11] - 2026-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ All notable changes to this project will be documented in this file.
   - **GO-2026-4971**: Panic in `Dial` and `LookupPort` when handling NUL byte on Windows in `net`
   - **GO-2026-4918**: Infinite loop in HTTP/2 transport when given bad `SETTINGS_MAX_FRAME_SIZE` in `net/http`
 
+- Bump `fast-uri` (transitive npm dev dependency via `@commitlint/cli`) from `3.1.0` → `3.1.2` to fix:
+  - **CVE-2026-6321** (GHSA-q3j6-qgpj-74h6): Path traversal via percent-encoded dot segments in URI normalization
+  - **CVE-2026-6322** (GHSA-v39h-62p7-jpjc): Host confusion via percent-encoded authority delimiters
+
 ### Changed
 
 - `go.mod` toolchain pin updated from `go1.26.2` to `go1.26.3`
 - `Dockerfile` builder stage updated from `golang:1.26.2-alpine` to `golang:1.26.3-alpine`
+- `package-lock.json` updated to resolve `fast-uri` to `3.1.2`
 
 ## [1.0.11] - 2026-04-15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - use specific Go version for reproducibility and security
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Kong/kwot
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/internal/kong/timeout_test.go
+++ b/internal/kong/timeout_test.go
@@ -13,9 +13,9 @@ import (
 // client timeout to the value in cfg.HTTPRequestTimeout, not a hardcoded value.
 func TestHTTPClientTimeoutDerivedFromConfig(t *testing.T) {
 	tests := []struct {
-		name            string
-		configuredSecs  int
-		wantTimeout     time.Duration
+		name           string
+		configuredSecs int
+		wantTimeout    time.Duration
 	}{
 		{
 			name:           "30 second timeout",

--- a/package-lock.json
+++ b/package-lock.json
@@ -602,9 +602,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Fixes all 4 open security alerts — 2 from the scheduled govulncheck scan (issue #24) and 2 Dependabot alerts.

### Go standard library (issue #24)

Bumps `go.mod` toolchain pin from `go1.26.2` → `go1.26.3` and `Dockerfile` builder stage to match.

| ID | Package | Description |
|----|---------|-------------|
| GO-2026-4971 | `net` | Panic in `Dial`/`LookupPort` on NUL byte (Windows) |
| GO-2026-4918 | `net/http` | Infinite loop in HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE` |

### npm dev dependency (Dependabot #3, #4)

Bumps transitive `fast-uri` from `3.1.0` → `3.1.2` (dev-only, via `@commitlint/cli` — not shipped in binary or Docker image).

| Alert | CVE | Description |
|-------|-----|-------------|
| #3 | CVE-2026-6321 | Path traversal via percent-encoded dot segments in URI normalization |
| #4 | CVE-2026-6322 | Host confusion via percent-encoded authority delimiters |

## Test plan

- [x] `make fmt` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all pass
- [x] `make build` — success
- [x] `GOTOOLCHAIN=go1.26.3 govulncheck ./...` — **No vulnerabilities found**
- [x] `npm audit` — no high/critical issues (remaining moderate is an unfixed `ajv` ReDoS in commitlint's dep tree, not flagged by Dependabot)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)