### PR TITLE
feat: env var interpolation in user_token and role comment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.13] - 2026-06-03
+
+### Added
+
+- **Env var interpolation in `user_token`** — `workspace-rbac-user.yaml` now supports `${VAR_NAME}` and `$VAR_NAME` syntax in the `user_token` field. kwot resolves the reference from the environment at runtime, enabling CI/CD pipelines (e.g. GitHub Actions secrets) to inject tokens without pre-processing YAML files. If the referenced env var is unset, kwot logs a warning and falls back to a random UUID (closes #31).
+- **Role comment support** — `workspace.yaml` RBAC entries now accept an optional `comment` field that is forwarded to Kong on role creation, making roles self-documenting in Kong Manager.
+
+### Security
+
+- Update Go toolchain from `go1.26.3` to `go1.26.4` to fix 2 Go standard library vulnerabilities:
+  - **GO-2026-5039**: Arbitrary inputs included in errors without escaping in `net/textproto`
+  - **GO-2026-5037**: Inefficient candidate hostname parsing in `crypto/x509`
+
+### Changed
+
+- `go.mod` toolchain pin updated from `go1.26.3` to `go1.26.4`
+- `Dockerfile` builder stage updated from `golang:1.26.3-alpine` to `golang:1.26.4-alpine`
+
 ## [1.0.12] - 2026-05-26
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - use specific Go version for reproducibility and security
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # ============================================================================
 
 BINARY_NAME=kwot
-VERSION?=1.0.12
+VERSION?=1.0.13
 BUILD_DIR=bin
 DOCS_DIR=docs
 GOCMD=go

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Kong/kwot
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -2,7 +2,8 @@ package models
 
 // Role represents a Kong RBAC role
 type Role struct {
-	Name string `json:"name"`
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
 }
 
 // RoleResponse represents the API response for a role

--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -15,6 +15,7 @@ type WorkspaceConfigDetail struct {
 // RoleDetail represents a role and its permissions
 type RoleDetail struct {
 	Role        string      `yaml:"role"`
+	Comment     string      `yaml:"comment,omitempty"`
 	Permissions interface{} `yaml:"permissions"` // Can be array or file path
 }
 

--- a/internal/roles/processor.go
+++ b/internal/roles/processor.go
@@ -296,7 +296,8 @@ func (p *Processor) createRole(workspaceName string, roleDetail models.RoleDetai
 	path := fmt.Sprintf("/%s/rbac/roles", workspaceName)
 
 	role := models.Role{
-		Name: roleDetail.Role,
+		Name:    roleDetail.Role,
+		Comment: roleDetail.Comment,
 	}
 
 	var result models.RoleResponse

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -525,8 +525,31 @@ func (p *Processor) getCurrentRBACUsers(workspaceName string) ([]string, error) 
 	return userNames, nil
 }
 
+// isValidEnvVarName reports whether name is a valid POSIX env var identifier:
+// must start with a letter or underscore, followed only by letters, digits, or underscores.
+func isValidEnvVarName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, c := range name {
+		switch {
+		case c == '_':
+			// always valid
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z':
+			// always valid
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false // digits not allowed at start
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // resolveEnvVar expands ${VAR} or $VAR references in s using os.Getenv.
-// Returns the original string unchanged if it is not an env var reference.
+// Only expands when the var name is a valid POSIX identifier; otherwise returns s unchanged.
 // Returns "" (triggering UUID fallback) if the referenced var is unset, and logs a warning.
 func resolveEnvVar(userName, s string) string {
 	if s == "" {
@@ -540,7 +563,7 @@ func resolveEnvVar(userName, s string) string {
 	} else {
 		return s
 	}
-	if varName == "" {
+	if !isValidEnvVarName(varName) {
 		return s
 	}
 	val := os.Getenv(varName)

--- a/internal/workspace/processor.go
+++ b/internal/workspace/processor.go
@@ -525,14 +525,42 @@ func (p *Processor) getCurrentRBACUsers(workspaceName string) ([]string, error) 
 	return userNames, nil
 }
 
+// resolveEnvVar expands ${VAR} or $VAR references in s using os.Getenv.
+// Returns the original string unchanged if it is not an env var reference.
+// Returns "" (triggering UUID fallback) if the referenced var is unset, and logs a warning.
+func resolveEnvVar(userName, s string) string {
+	if s == "" {
+		return s
+	}
+	var varName string
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
+		varName = s[2 : len(s)-1]
+	} else if strings.HasPrefix(s, "$") {
+		varName = s[1:]
+	} else {
+		return s
+	}
+	if varName == "" {
+		return s
+	}
+	val := os.Getenv(varName)
+	if val == "" {
+		logger.Warnf("user_token for '%s' references env var '%s' which is not set — falling back to random UUID", userName, varName)
+	}
+	return val
+}
+
 // createOrUpdateRBACUser creates or updates an RBAC user
 // Matches Node.js approach: just POST and handle 409 conflict gracefully.
 // NOTE: user_token is only applied on initial creation. If the user already
 // exists (409), the configured token is NOT reconciled — Kong does not expose
 // a way to retrieve the existing token for comparison, so we leave it unchanged.
 func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBACUser) error {
-	// Use user-specified token if provided, otherwise generate a random UUID
-	userToken := user.UserToken
+	// Resolve env var references in user_token (e.g. ${MY_SECRET})
+	resolvedToken := resolveEnvVar(user.Name, user.UserToken)
+
+	// Use resolved token if non-empty, otherwise generate a random UUID
+	userToken := resolvedToken
 	if userToken == "" {
 		userToken = uuid.New().String()
 	}
@@ -549,7 +577,7 @@ func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBA
 		if strings.Contains(errStr, "409") || strings.Contains(errStr, "conflict") ||
 			strings.Contains(errStr, "UNIQUE violation") || strings.Contains(errStr, "already exists") ||
 			strings.Contains(errStr, "Duplicate resource") {
-			if user.UserToken != "" {
+			if resolvedToken != "" {
 				logger.Warnf("RBAC user '%s' already exists in workspace '%s' — configured user_token was not applied", user.Name, workspaceName)
 			} else {
 				logger.Warnf("RBAC user '%s' already exists in workspace '%s'", user.Name, workspaceName)
@@ -559,7 +587,7 @@ func (p *Processor) createOrUpdateRBACUser(workspaceName string, user models.RBA
 		return fmt.Errorf("failed to create RBAC user: %w", err)
 	}
 
-	if user.UserToken != "" {
+	if resolvedToken != "" {
 		logger.Debugf("RBAC user '%s' created in workspace '%s' with configured user_token", user.Name, workspaceName)
 	}
 	logger.Infof("RBAC user '%s' created in workspace '%s'", user.Name, workspaceName)

--- a/internal/workspace/processor_test.go
+++ b/internal/workspace/processor_test.go
@@ -276,12 +276,20 @@ func TestResolveEnvVar(t *testing.T) {
 		input    string
 		expected string
 	}{
+		// valid env var references — should resolve
 		{"${MY_TOKEN}", "secret123"},
 		{"$MY_TOKEN", "secret123"},
-		{"literal-token", "literal-token"},
-		{"", ""},
+		// unset var — should return "" (UUID fallback)
 		{"${UNSET_VAR}", ""},
 		{"$UNSET_VAR", ""},
+		// literal tokens — must be returned unchanged even when starting with $
+		{"literal-token", "literal-token"},
+		{"", ""},
+		{"$abc-def", "$abc-def"},     // hyphen makes it an invalid identifier
+		{"${abc-def}", "${abc-def}"}, // hyphen inside braces — also invalid
+		{"$1TOKEN", "$1TOKEN"},       // starts with digit — invalid
+		{"$", "$"},                   // bare dollar — invalid
+		{"${}", "${}"},               // empty braces — invalid
 	}
 
 	for _, tc := range tests {
@@ -295,5 +303,28 @@ func TestResolveEnvVar(t *testing.T) {
 	t.Setenv("DYNAMIC_TOKEN", "dynval")
 	if got := resolveEnvVar("u", "${DYNAMIC_TOKEN}"); got != "dynval" {
 		t.Errorf("expected dynval, got %q", got)
+	}
+}
+
+func TestIsValidEnvVarName(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"MY_TOKEN", true},
+		{"_PRIVATE", true},
+		{"TOKEN123", true},
+		{"A", true},
+		{"", false},
+		{"1TOKEN", false},
+		{"abc-def", false},
+		{"abc.def", false},
+		{"abc def", false},
+	}
+	for _, tc := range tests {
+		got := isValidEnvVarName(tc.name)
+		if got != tc.valid {
+			t.Errorf("isValidEnvVarName(%q) = %v, want %v", tc.name, got, tc.valid)
+		}
 	}
 }

--- a/internal/workspace/processor_test.go
+++ b/internal/workspace/processor_test.go
@@ -268,3 +268,32 @@ func TestApplyPlugin_NonWorkspace404NotRetried(t *testing.T) {
 		t.Errorf("non-workspace 404 must not retry: expected 1 call, got %d", callCount)
 	}
 }
+
+func TestResolveEnvVar(t *testing.T) {
+	t.Setenv("MY_TOKEN", "secret123")
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"${MY_TOKEN}", "secret123"},
+		{"$MY_TOKEN", "secret123"},
+		{"literal-token", "literal-token"},
+		{"", ""},
+		{"${UNSET_VAR}", ""},
+		{"$UNSET_VAR", ""},
+	}
+
+	for _, tc := range tests {
+		got := resolveEnvVar("test-user", tc.input)
+		if got != tc.expected {
+			t.Errorf("resolveEnvVar(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+
+	// Ensure a dynamically set env var is resolved (t.Setenv handles cleanup)
+	t.Setenv("DYNAMIC_TOKEN", "dynval")
+	if got := resolveEnvVar("u", "${DYNAMIC_TOKEN}"); got != "dynval" {
+		t.Errorf("expected dynval, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Env var interpolation in `user_token`** — `workspace-rbac-user.yaml` now supports `${VAR_NAME}` and `$VAR_NAME` syntax in the `user_token` field. kwot resolves the reference from the environment at runtime, enabling CI/CD pipelines (e.g. GitHub Actions secrets) to inject tokens without pre-processing YAML files. If the referenced env var is unset, kwot logs a warning and falls back to a random UUID. Closes #31.
- **Role comment support** — `workspace.yaml` RBAC entries now accept an optional `comment` field forwarded to Kong on role creation, making roles self-documenting in Kong Manager.
- **Go toolchain bump to go1.26.4** — fixes GO-2026-5039 (`net/textproto`) and GO-2026-5037 (`crypto/x509`).

## Usage

**Env var token injection:**
```yaml
# workspace-rbac-user.yaml
- name: ci-deploy-user
  user_token: "${CI_DEPLOY_TOKEN}"
  roles:
    - PlatformEditor
```
Set `CI_DEPLOY_TOKEN` as a GitHub Actions secret or shell env var before running `kwot apply`.

**Role comments:**
```yaml
# workspace.yaml
rbac:
  - role: PlatformEditor
    comment: "Full access to all endpoints in the Workspace, except the RBAC Admin API."
    permissions: ./environments/platform-editor.yaml
```

## Test plan

- [x] `make fmt` — no issues
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass including new `TestResolveEnvVar`
- [x] `make build` — binary builds at v1.0.13
- [x] `govulncheck ./...` — clean with go1.26.4
- [x] Tested locally: `${TOKEN}` and `$TOKEN` syntax both resolve correctly; unset var warns and falls back to UUID
- [x] Tested locally: role `comment` field appears in Kong Manager after `kwot apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)